### PR TITLE
[codex] Emit lifecycle ceremony events

### DIFF
--- a/.aether/CONTEXT.md
+++ b/.aether/CONTEXT.md
@@ -8,7 +8,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Last Updated** | 2026-04-24T12:00:05Z |
+| **Last Updated** | 2026-04-24T12:14:23Z |
 | **Current Phase** | 1 |
 | **Phase Name** | Assumptions and gap audit |
 | **Phase Status** | ready |
@@ -70,11 +70,13 @@ TypeScript lifecycle-context rendering slice is in the working tree: `.aether/ts
 
 Broad checkpoint verification passed on 2026-04-24T11:27:54Z: TS install/typecheck/test/build, `gofmt`, `git diff --check`, `go test ./cmd -count=1`, `go test ./... -count=1 -timeout 300s`, and `go vet ./...`.
 
-GitHub PR status: PR #5, PR #6, and PR #7 are merged. Current implementation branch is `codex/ceremony-lifecycle-events-v16`, based on `origin/main` at PR #7.
+GitHub PR status: PR #5, PR #6, and PR #7 are merged. PR #8 is still open as a draft for `codex/ceremony-lifecycle-events-v16`; it is not on `main` yet. The old `codex/ceremony-narrator-foundation-v16` branch still appears on GitHub because PR #7 was merged but the source branch was not deleted.
 
 Go-side wrapper smoke passed with `AETHER_OUTPUT_MODE=json go run ./cmd/aether build 1 --plan-only`: the standard-depth manifest emitted builder execution wave 11, Probe wave 12, and Watcher wave 13. True Claude/OpenCode Task-tool smoke remains pending because Codex cannot execute those platform wrapper tools directly.
 
 Phase 6 first Go-backed lifecycle ceremony slice is complete in the working tree: `emitLifecycleCeremony` persists non-build ceremony events to `event-bus.jsonl`; `pheromone-write` now emits `ceremony.pheromone.emit`; `aether seal` now emits `ceremony.chamber.seal`. Focused tests, `go test ./cmd -count=1`, `go test ./... -count=1 -timeout 300s`, `go vet ./...`, and `git diff --check` passed.
+
+Phase 6 plan/colonize/continue ceremony slice is complete in the working tree: `pkg/events/ceremony.go` defines `ceremony.plan.*`, `ceremony.colonize.*`, and `ceremony.continue.*` wave/spawn topics; `cmd/ceremony_emitter.go` has a shared lifecycle sequence emitter; `plan`, `plan-finalize`, `colonize`, `continue`, and `continue-finalize` persist retrospective wave start/spawn/wave end events from Go-owned command results. Focused ceremony tests, `go test ./cmd -count=1`, `go test ./... -count=1 -timeout 300s`, `go vet ./...`, and `git diff --check` passed.
 
 ---
 
@@ -140,13 +142,15 @@ Phase 6 first Go-backed lifecycle ceremony slice is complete in the working tree
 - 2026-04-24T11:36:13Z|go_side_wrapper_smoke|test|PR #6 clean/mergeable; build --plan-only emitted execution_plan for builder/probe/watcher waves
 - 2026-04-24T11:56:31Z|phase6_lifecycle_events|build|Pheromone and chamber seal ceremony events now persist through Go-owned lifecycle hooks
 - 2026-04-24T12:00:05Z|phase6_lifecycle_verified|test|Pheromone/chamber ceremony event slice passed focused, full cmd, full repo, vet, and whitespace checks
+- 2026-04-24T12:14:23Z|phase6_wave_events|build|Plan, colonize, and continue commands now persist ceremony wave/spawn event sequences from Go-owned lifecycle results
+- 2026-04-24T12:14:23Z|phase6_wave_events_verified|test|Lifecycle wave event slice passed focused ceremony tests, full cmd, full repo, vet, and whitespace checks
 
 ---
 
 ## Next Steps
 
-1. Commit/push the Phase 6 pheromone/chamber ceremony event slice
-2. Continue lifecycle event emission for plan, continue, colonize, and worker/skill context
+1. Commit/push the Phase 6 plan/colonize/continue lifecycle wave event slice to PR #8
+2. Continue Phase 6 worker/skill context events, especially `ceremony.skill.activate` from real skill activation points
 3. Run true Claude/OpenCode build wrapper smoke with platform Task-tool agents when available
 4. Keep Go as state/event source of truth; wrappers own Task-tool spawning
 

--- a/.aether/CONTEXT.md
+++ b/.aether/CONTEXT.md
@@ -8,7 +8,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Last Updated** | 2026-04-24T11:36:13Z |
+| **Last Updated** | 2026-04-24T12:00:05Z |
 | **Current Phase** | 1 |
 | **Phase Name** | Assumptions and gap audit |
 | **Phase Status** | ready |
@@ -70,9 +70,11 @@ TypeScript lifecycle-context rendering slice is in the working tree: `.aether/ts
 
 Broad checkpoint verification passed on 2026-04-24T11:27:54Z: TS install/typecheck/test/build, `gofmt`, `git diff --check`, `go test ./cmd -count=1`, `go test ./... -count=1 -timeout 300s`, and `go vet ./...`.
 
-GitHub PR status: previous PR #5 for this branch is already merged/closed and only covered the early branch state through `c1880184`. Current draft PR is #6: `https://github.com/calcosmic/Aether/pull/6`. The branch has merged the PR #5 squash commit from `main` with an ancestry-only merge because `origin/main` already matched the branch's `c1880184` tree.
+GitHub PR status: PR #5, PR #6, and PR #7 are merged. Current implementation branch is `codex/ceremony-lifecycle-events-v16`, based on `origin/main` at PR #7.
 
-PR #6 status after sync: draft, clean, mergeable, 48 changed files. Go-side wrapper smoke passed with `AETHER_OUTPUT_MODE=json go run ./cmd/aether build 1 --plan-only`: the standard-depth manifest emitted builder execution wave 11, Probe wave 12, and Watcher wave 13. True Claude/OpenCode Task-tool smoke remains pending because Codex cannot execute those platform wrapper tools directly.
+Go-side wrapper smoke passed with `AETHER_OUTPUT_MODE=json go run ./cmd/aether build 1 --plan-only`: the standard-depth manifest emitted builder execution wave 11, Probe wave 12, and Watcher wave 13. True Claude/OpenCode Task-tool smoke remains pending because Codex cannot execute those platform wrapper tools directly.
+
+Phase 6 first Go-backed lifecycle ceremony slice is complete in the working tree: `emitLifecycleCeremony` persists non-build ceremony events to `event-bus.jsonl`; `pheromone-write` now emits `ceremony.pheromone.emit`; `aether seal` now emits `ceremony.chamber.seal`. Focused tests, `go test ./cmd -count=1`, `go test ./... -count=1 -timeout 300s`, `go vet ./...`, and `git diff --check` passed.
 
 ---
 
@@ -136,14 +138,17 @@ PR #6 status after sync: draft, clean, mergeable, 48 changed files. Go-side wrap
 - 2026-04-24T11:27:54Z|checkpoint_verified|test|Phase 4 specialist execution-plan and TS lifecycle-context checkpoint passed TS, Go, vet, and whitespace verification
 - 2026-04-24T11:33:58Z|draft_pr_opened|github|Draft PR #6 opened and branch ancestry synced with main's PR #5 squash commit
 - 2026-04-24T11:36:13Z|go_side_wrapper_smoke|test|PR #6 clean/mergeable; build --plan-only emitted execution_plan for builder/probe/watcher waves
+- 2026-04-24T11:56:31Z|phase6_lifecycle_events|build|Pheromone and chamber seal ceremony events now persist through Go-owned lifecycle hooks
+- 2026-04-24T12:00:05Z|phase6_lifecycle_verified|test|Pheromone/chamber ceremony event slice passed focused, full cmd, full repo, vet, and whitespace checks
 
 ---
 
 ## Next Steps
 
-1. Run true Claude/OpenCode build wrapper smoke with platform Task-tool agents
-2. Continue in order with lifecycle event emission after wrapper smoke
-3. Keep Go as state/event source of truth; wrappers own Task-tool spawning
+1. Commit/push the Phase 6 pheromone/chamber ceremony event slice
+2. Continue lifecycle event emission for plan, continue, colonize, and worker/skill context
+3. Run true Claude/OpenCode build wrapper smoke with platform Task-tool agents when available
+4. Keep Go as state/event source of truth; wrappers own Task-tool spawning
 
 ---
 

--- a/.aether/docs/ceremony-revival-v1.6-handoff.md
+++ b/.aether/docs/ceremony-revival-v1.6-handoff.md
@@ -1,11 +1,11 @@
 # Ceremony Revival v1.6 Handoff
 
-Last updated: 2026-04-24T11:36:13Z
+Last updated: 2026-04-24T12:00:05Z
 
-Branch: `codex/ceremony-narrator-foundation-v16`
-Remote branch: `origin/codex/ceremony-narrator-foundation-v16`
+Branch: `codex/ceremony-lifecycle-events-v16`
+Base: `origin/main` after merged PR #7
 Previous PR: `https://github.com/calcosmic/Aether/pull/5` (merged/closed; covered only the early branch state through `c1880184`)
-Current PR: `https://github.com/calcosmic/Aether/pull/6` (draft)
+Merged PRs: `https://github.com/calcosmic/Aether/pull/6`, `https://github.com/calcosmic/Aether/pull/7`
 
 ## Purpose
 
@@ -51,12 +51,12 @@ committed directly while the persisted colony lifecycle was not advanced through
 | Phase 6: full lifecycle ceremony and skills | Partially implemented | Build ceremony emits from Go; uncommitted TS slice renders generic lifecycle stages and context notices | Emit Go-backed events for plan, continue, colonize, pheromones, chamber sealing, graves/entomb; surface skill/QUEEN/Hive/midden context from real state |
 | Phase 7: parity verification and release | Not done | Release/rollback notes exist | Cross-platform smoke, install/update release checks, PR review, release hardening |
 
-Safe continuation point: PR #6 is open as a draft. The verified Phase 4
-specialist execution-plan and TypeScript lifecycle-context checkpoint is pushed,
-and the branch has merged the PR #5 squash commit from `main` with an
-ancestry-only merge. PR #6 is clean and mergeable. Go-side wrapper smoke passed
-for `build 1 --plan-only`; true Claude/OpenCode Task-tool smoke remains next
-before moving on to later lifecycle event emission.
+Safe continuation point: PR #6 and PR #7 are merged. Current branch is
+`codex/ceremony-lifecycle-events-v16` from `origin/main`. Go-side wrapper smoke
+passed for `build 1 --plan-only`; true Claude/OpenCode Task-tool smoke remains
+pending because Codex cannot execute those platform Task-tool wrappers directly.
+The current working-tree slice starts Phase 6 Go-backed lifecycle ceremony
+emission for pheromones and chamber sealing.
 
 ## Already Shipped On This Branch
 
@@ -981,6 +981,38 @@ Skill work:
 - Ensure wrapper-spawned agents receive matched skill sections.
 - Emit `ceremony.skill.activate` when a worker activates a skill.
 
+## Working Tree Slice: Phase 6 Pheromone And Chamber Events
+
+Date: 2026-04-24
+
+This slice begins Go-backed lifecycle ceremony emission beyond build.
+
+Changed files:
+
+- `cmd/ceremony_emitter.go`
+- `cmd/pheromone_write.go`
+- `cmd/codex_workflow_cmds.go`
+- `cmd/ceremony_emitter_test.go`
+
+Implemented behavior:
+
+- `emitLifecycleCeremony` persists non-build ceremony events to
+  `event-bus.jsonl` using the existing `pkg/events` bus.
+- `pheromone-write` emits `ceremony.pheromone.emit` with signal type, strength,
+  created/reinforced status, and sanitized signal text.
+- `aether seal` emits `ceremony.chamber.seal` with Crowned Anthill status and
+  completed/total phase counts.
+- The generic publisher reuses the existing ceremony payload trimming rules so
+  user-controlled event text is bounded before persistence.
+
+Verification run:
+
+- `go test ./cmd -run 'TestLifecycleCeremonyPersistsTrimmedEvent|TestPheromoneWriteEmitsCeremonyEvent|TestSealEmitsChamberCeremonyEvent|TestBuildCeremonyEmitter' -count=1`
+- `git diff --check`
+- `go test ./cmd -count=1`
+- `go test ./... -count=1 -timeout 300s`
+- `go vet ./...`
+
 ## Release And Rollback
 
 Rollback controls:
@@ -1001,8 +1033,10 @@ Before release:
 
 ## Current Next Step
 
-Next, continue in order with live build-wrapper smoke before starting later
-lifecycle event emission. The preconditions now satisfied are:
+Next, commit and push the Phase 6 pheromone/chamber event slice, then continue
+lifecycle event emission for plan, continue, colonize, and visible worker/skill
+context. Platform Task-tool smoke is still required when Claude or OpenCode is
+available. The preconditions now satisfied are:
 
 1. hub fallback smoke passed in a temporary HOME;
 2. TTY live redraw is consciously deferred;
@@ -1016,4 +1050,7 @@ lifecycle event emission. The preconditions now satisfied are:
 8. PR #6 is clean/mergeable;
 9. Go-side wrapper smoke passed for
    `AETHER_OUTPUT_MODE=json go run ./cmd/aether build 1 --plan-only`, producing
-   standard-depth builder wave 11, Probe wave 12, and Watcher wave 13.
+   standard-depth builder wave 11, Probe wave 12, and Watcher wave 13;
+10. PR #6 and PR #7 are merged;
+11. Phase 6 pheromone/chamber event hooks are implemented in the working tree
+    with focused, full cmd, full repo, vet, and whitespace checks passing.

--- a/.aether/docs/ceremony-revival-v1.6-handoff.md
+++ b/.aether/docs/ceremony-revival-v1.6-handoff.md
@@ -1,11 +1,12 @@
 # Ceremony Revival v1.6 Handoff
 
-Last updated: 2026-04-24T12:00:05Z
+Last updated: 2026-04-24T12:14:23Z
 
 Branch: `codex/ceremony-lifecycle-events-v16`
 Base: `origin/main` after merged PR #7
 Previous PR: `https://github.com/calcosmic/Aether/pull/5` (merged/closed; covered only the early branch state through `c1880184`)
 Merged PRs: `https://github.com/calcosmic/Aether/pull/6`, `https://github.com/calcosmic/Aether/pull/7`
+Open PR: `https://github.com/calcosmic/Aether/pull/8` (draft; not merged)
 
 ## Purpose
 
@@ -33,7 +34,7 @@ There are two separate progress tracks in this checkout:
    lifecycle state only. Do not manually edit it to match code progress.
 2. **Branch implementation progress**: git commits plus this tracked handoff are
    the source of truth for what has actually been implemented on
-   `codex/ceremony-narrator-foundation-v16`.
+   `codex/ceremony-lifecycle-events-v16`.
 
 This mismatch is expected for this branch because implementation slices were
 committed directly while the persisted colony lifecycle was not advanced through
@@ -48,15 +49,17 @@ committed directly while the persisted colony lifecycle was not advanced through
 | Phase 3: rolling activity display | Implemented foundation | `.aether/ts/narrator.ts`, multi-wave activity tests, `dist/narrator.js` | TTY live redraw/debounce deferred until real terminal contract is clear |
 | Phase 4: build subagent bridge | Implemented for wrappers | `build --plan-only`, `build-finalize`, manifest `execution_plan`, Claude/OpenCode build wrappers, wrapper contract tests | Live platform smoke and any future specialist prompt polish |
 | Phase 5: continue and plan orchestration | Implemented for wrappers | `continue --plan-only`, `continue-finalize`, `plan --plan-only`, `plan-finalize`, wrapper contract tests | Live platform smoke; stall/confidence ceremony polish |
-| Phase 6: full lifecycle ceremony and skills | Partially implemented | Build ceremony emits from Go; uncommitted TS slice renders generic lifecycle stages and context notices | Emit Go-backed events for plan, continue, colonize, pheromones, chamber sealing, graves/entomb; surface skill/QUEEN/Hive/midden context from real state |
+| Phase 6: full lifecycle ceremony and skills | Partially implemented | Build ceremony emits from Go; TS renders generic lifecycle stages and context notices; Go emits pheromone/chamber plus plan/colonize/continue wave events | Emit skill activation and remaining QUEEN/Hive/midden/graveyard context from real state |
 | Phase 7: parity verification and release | Not done | Release/rollback notes exist | Cross-platform smoke, install/update release checks, PR review, release hardening |
 
-Safe continuation point: PR #6 and PR #7 are merged. Current branch is
-`codex/ceremony-lifecycle-events-v16` from `origin/main`. Go-side wrapper smoke
-passed for `build 1 --plan-only`; true Claude/OpenCode Task-tool smoke remains
-pending because Codex cannot execute those platform Task-tool wrappers directly.
-The current working-tree slice starts Phase 6 Go-backed lifecycle ceremony
-emission for pheromones and chamber sealing.
+Safe continuation point: PR #6 and PR #7 are merged. PR #8 is still open as a
+draft for `codex/ceremony-lifecycle-events-v16`; it is not on `main` yet.
+The old `codex/ceremony-narrator-foundation-v16` branch still appears on
+GitHub because PR #7 was merged without deleting its source branch. Go-side
+wrapper smoke passed for `build 1 --plan-only`; true Claude/OpenCode Task-tool
+smoke remains pending because Codex cannot execute those platform Task-tool
+wrappers directly. The current working-tree slice continues Phase 6 Go-backed
+lifecycle ceremony emission for plan, colonize, and continue wave events.
 
 ## Already Shipped On This Branch
 
@@ -1013,6 +1016,47 @@ Verification run:
 - `go test ./... -count=1 -timeout 300s`
 - `go vet ./...`
 
+## Working Tree Slice: Phase 6 Plan, Colonize, And Continue Wave Events
+
+Date: 2026-04-24
+
+This slice broadens Go-backed lifecycle ceremony emission beyond build,
+pheromones, and seal.
+
+Changed files:
+
+- `pkg/events/ceremony.go`
+- `cmd/ceremony_emitter.go`
+- `cmd/codex_plan.go`
+- `cmd/codex_plan_finalize.go`
+- `cmd/codex_colonize.go`
+- `cmd/codex_continue.go`
+- `cmd/codex_continue_finalize.go`
+- `cmd/ceremony_emitter_test.go`
+
+Implemented behavior:
+
+- New event topics:
+  `ceremony.plan.wave.start`, `ceremony.plan.spawn`,
+  `ceremony.plan.wave.end`, `ceremony.colonize.wave.start`,
+  `ceremony.colonize.spawn`, `ceremony.colonize.wave.end`,
+  `ceremony.continue.wave.start`, `ceremony.continue.spawn`, and
+  `ceremony.continue.wave.end`.
+- `emitLifecycleCeremonySequence` converts completed Go-owned lifecycle worker
+  results into retrospective wave start/spawn/wave end event sequences.
+- `plan` and `plan-finalize` now persist Scout/Route-Setter ceremony events.
+- `colonize` now persists surveyor ceremony events.
+- `continue` and `continue-finalize` now persist verification, review, and
+  housekeeping ceremony events from the final worker flow.
+
+Verification run:
+
+- `go test ./cmd -run 'Test.*Ceremony|TestCeremony|TestPlanEmitsLifecycleCeremonyEvents|TestColonizeEmitsLifecycleCeremonyEvents|TestContinueEmitsLifecycleCeremonyEvents' -count=1`
+- `go test ./cmd -count=1`
+- `git diff --check`
+- `go test ./... -count=1 -timeout 300s`
+- `go vet ./...`
+
 ## Release And Rollback
 
 Rollback controls:
@@ -1033,24 +1077,25 @@ Before release:
 
 ## Current Next Step
 
-Next, commit and push the Phase 6 pheromone/chamber event slice, then continue
-lifecycle event emission for plan, continue, colonize, and visible worker/skill
-context. Platform Task-tool smoke is still required when Claude or OpenCode is
-available. The preconditions now satisfied are:
+Next, commit and push the Phase 6 plan/colonize/continue wave event slice to
+PR #8, then continue with visible worker/skill context events. Platform
+Task-tool smoke is still required when Claude or OpenCode is available. The
+preconditions now satisfied are:
 
 1. hub fallback smoke passed in a temporary HOME;
 2. TTY live redraw is consciously deferred;
 3. multi-wave TS fixture passes;
 4. build, continue, and plan wrappers now have plan-only/finalizer bridges;
 5. focused Go, full Go, TS, vet, and whitespace gates pass;
-6. draft PR #6 is open;
+6. PR #8 is open as a draft and not merged;
 7. the branch has merged the PR #5 squash commit from `main` with an
    ancestry-only merge because its tree already matched branch commit
    `c1880184`;
-8. PR #6 is clean/mergeable;
+8. PR #6 and PR #7 are merged;
 9. Go-side wrapper smoke passed for
    `AETHER_OUTPUT_MODE=json go run ./cmd/aether build 1 --plan-only`, producing
    standard-depth builder wave 11, Probe wave 12, and Watcher wave 13;
-10. PR #6 and PR #7 are merged;
-11. Phase 6 pheromone/chamber event hooks are implemented in the working tree
-    with focused, full cmd, full repo, vet, and whitespace checks passing.
+10. Phase 6 pheromone/chamber event hooks are implemented and verified;
+11. Phase 6 plan/colonize/continue wave event hooks are implemented in the
+    working tree with focused, full cmd, full repo, vet, and whitespace checks
+    passing.

--- a/cmd/ceremony_emitter.go
+++ b/cmd/ceremony_emitter.go
@@ -129,6 +129,216 @@ func emitLifecycleCeremony(topic string, payload events.CeremonyPayload, source 
 	_, _ = bus.Publish(context.Background(), topic, raw, source)
 }
 
+type lifecycleCeremonyTopics struct {
+	WaveStart string
+	Spawn     string
+	WaveEnd   string
+}
+
+type lifecycleCeremonyStep struct {
+	Wave     int
+	SpawnID  string
+	Caste    string
+	Name     string
+	TaskID   string
+	Task     string
+	Status   string
+	Message  string
+	Blockers []string
+}
+
+func emitLifecycleCeremonySequence(topics lifecycleCeremonyTopics, source, lifecycle string, phase int, phaseName string, steps []lifecycleCeremonyStep) {
+	if len(steps) == 0 || strings.TrimSpace(topics.WaveStart) == "" || strings.TrimSpace(topics.Spawn) == "" || strings.TrimSpace(topics.WaveEnd) == "" {
+		return
+	}
+	lifecycle = strings.TrimSpace(lifecycle)
+	if lifecycle == "" {
+		lifecycle = "lifecycle"
+	}
+
+	waves := map[int][]lifecycleCeremonyStep{}
+	waveOrder := []int{}
+	for _, step := range steps {
+		wave := step.Wave
+		if wave <= 0 {
+			wave = 1
+		}
+		step.Wave = wave
+		if _, seen := waves[wave]; !seen {
+			waveOrder = append(waveOrder, wave)
+		}
+		waves[wave] = append(waves[wave], step)
+	}
+
+	for _, wave := range waveOrder {
+		waveSteps := waves[wave]
+		emitLifecycleCeremony(topics.WaveStart, events.CeremonyPayload{
+			Phase:     phase,
+			PhaseName: phaseName,
+			Wave:      wave,
+			Total:     len(waveSteps),
+			Status:    "starting",
+			Message:   fmt.Sprintf("%s wave %d with %d worker(s)", lifecycle, wave, len(waveSteps)),
+		}, source)
+
+		completed := 0
+		blockers := []string{}
+		for _, step := range waveSteps {
+			status := ceremonyStepStatus(step.Status)
+			if ceremonyStepCompleted(status) {
+				completed++
+			}
+			blockers = append(blockers, step.Blockers...)
+			if !ceremonyStepCompleted(status) && strings.TrimSpace(step.Message) != "" {
+				blockers = append(blockers, step.Message)
+			}
+			emitLifecycleCeremony(topics.Spawn, events.CeremonyPayload{
+				Phase:     phase,
+				PhaseName: phaseName,
+				Wave:      wave,
+				SpawnID:   step.SpawnID,
+				Caste:     step.Caste,
+				Name:      step.Name,
+				TaskID:    step.TaskID,
+				Task:      step.Task,
+				Status:    status,
+				Message:   step.Message,
+				Blockers:  step.Blockers,
+			}, source)
+		}
+
+		waveStatus := "completed"
+		if completed < len(waveSteps) || len(blockers) > 0 {
+			waveStatus = "blocked"
+		}
+		emitLifecycleCeremony(topics.WaveEnd, events.CeremonyPayload{
+			Phase:     phase,
+			PhaseName: phaseName,
+			Wave:      wave,
+			Status:    waveStatus,
+			Completed: completed,
+			Total:     len(waveSteps),
+			Blockers:  blockers,
+			Message:   fmt.Sprintf("%s wave %d %s", lifecycle, wave, waveStatus),
+		}, source)
+	}
+}
+
+func ceremonyStepStatus(status string) string {
+	status = strings.TrimSpace(status)
+	if status == "" || status == "spawned" || status == "planned" {
+		return "completed"
+	}
+	return status
+}
+
+func ceremonyStepCompleted(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "", "completed", "manually-reconciled", "skipped":
+		return true
+	default:
+		return false
+	}
+}
+
+func emitPlanCeremonyDispatchSequence(source string, dispatches []codexPlanningDispatch) {
+	steps := make([]lifecycleCeremonyStep, 0, len(dispatches))
+	for idx, dispatch := range dispatches {
+		wave := dispatch.Wave
+		if wave <= 0 {
+			wave = idx + 1
+		}
+		taskID := strings.TrimSpace(dispatch.TaskID)
+		if taskID == "" {
+			taskID = fmt.Sprintf("plan-%d", idx)
+		}
+		message := strings.TrimSpace(dispatch.Summary)
+		if message == "" {
+			message = strings.Join(dispatch.Outputs, ", ")
+		}
+		steps = append(steps, lifecycleCeremonyStep{
+			Wave:     wave,
+			SpawnID:  taskID,
+			Caste:    dispatch.Caste,
+			Name:     dispatch.Name,
+			TaskID:   taskID,
+			Task:     dispatch.Task,
+			Status:   dispatch.Status,
+			Message:  message,
+			Blockers: append([]string{}, dispatch.Blockers...),
+		})
+	}
+	emitLifecycleCeremonySequence(lifecycleCeremonyTopics{
+		WaveStart: events.CeremonyTopicPlanWaveStart,
+		Spawn:     events.CeremonyTopicPlanSpawn,
+		WaveEnd:   events.CeremonyTopicPlanWaveEnd,
+	}, source, "plan", 0, "Planning", steps)
+}
+
+func emitColonizeCeremonyDispatchSequence(source string, dispatches []codexSurveyorDispatch) {
+	steps := make([]lifecycleCeremonyStep, 0, len(dispatches))
+	for idx, dispatch := range dispatches {
+		taskID := fmt.Sprintf("survey-%d", idx)
+		message := strings.TrimSpace(dispatch.Summary)
+		if message == "" {
+			message = strings.Join(dispatch.Outputs, ", ")
+		}
+		steps = append(steps, lifecycleCeremonyStep{
+			Wave:    1,
+			SpawnID: taskID,
+			Caste:   dispatch.Caste,
+			Name:    dispatch.Name,
+			TaskID:  taskID,
+			Task:    dispatch.Task,
+			Status:  dispatch.Status,
+			Message: message,
+		})
+	}
+	emitLifecycleCeremonySequence(lifecycleCeremonyTopics{
+		WaveStart: events.CeremonyTopicColonizeWaveStart,
+		Spawn:     events.CeremonyTopicColonizeSpawn,
+		WaveEnd:   events.CeremonyTopicColonizeWaveEnd,
+	}, source, "colonize", 0, "Territory Survey", steps)
+}
+
+func emitContinueCeremonyFlowSequence(source string, phase colony.Phase, workerFlow []codexContinueWorkerFlowStep) {
+	steps := make([]lifecycleCeremonyStep, 0, len(workerFlow))
+	for idx, step := range workerFlow {
+		taskID := fmt.Sprintf("continue-%d", idx)
+		if stage := strings.TrimSpace(step.Stage); stage != "" {
+			taskID = fmt.Sprintf("continue-%s-%d", stage, idx)
+		}
+		steps = append(steps, lifecycleCeremonyStep{
+			Wave:    continueCeremonyWaveForStage(step.Stage),
+			SpawnID: taskID,
+			Caste:   step.Caste,
+			Name:    step.Name,
+			TaskID:  taskID,
+			Task:    continueWorkerFlowTask(step),
+			Status:  step.Status,
+			Message: step.Summary,
+		})
+	}
+	emitLifecycleCeremonySequence(lifecycleCeremonyTopics{
+		WaveStart: events.CeremonyTopicContinueWaveStart,
+		Spawn:     events.CeremonyTopicContinueSpawn,
+		WaveEnd:   events.CeremonyTopicContinueWaveEnd,
+	}, source, "continue", phase.ID, phase.Name, steps)
+}
+
+func continueCeremonyWaveForStage(stage string) int {
+	switch strings.ToLower(strings.TrimSpace(stage)) {
+	case "verification":
+		return 1
+	case "review":
+		return 2
+	case "housekeeping":
+		return 3
+	default:
+		return 1
+	}
+}
+
 func syntheticCeremonyEvent(topic string, payload json.RawMessage, source string) events.Event {
 	now := time.Now().UTC()
 	return events.Event{

--- a/cmd/ceremony_emitter.go
+++ b/cmd/ceremony_emitter.go
@@ -112,6 +112,23 @@ func (e *buildCeremonyEmitter) emitToNarrator(evt events.Event) {
 	e.narrator.EmitEvent(evt)
 }
 
+func emitLifecycleCeremony(topic string, payload events.CeremonyPayload, source string) {
+	if store == nil || strings.TrimSpace(topic) == "" {
+		return
+	}
+	source = strings.TrimSpace(source)
+	if source == "" {
+		source = "aether"
+	}
+	payload = trimCeremonyPayload(payload)
+	raw, err := payload.RawMessage()
+	if err != nil {
+		return
+	}
+	bus := events.NewBus(store, events.DefaultConfig())
+	_, _ = bus.Publish(context.Background(), topic, raw, source)
+}
+
 func syntheticCeremonyEvent(topic string, payload json.RawMessage, source string) events.Event {
 	now := time.Now().UTC()
 	return events.Event{

--- a/cmd/ceremony_emitter_test.go
+++ b/cmd/ceremony_emitter_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -116,6 +117,139 @@ func TestBuildCeremonyEmitterTrimsUserControlledPayload(t *testing.T) {
 		if len(blocker) > ceremonyListItemLimit {
 			t.Fatalf("blocker not trimmed: %d", len(blocker))
 		}
+	}
+}
+
+func TestLifecycleCeremonyPersistsTrimmedEvent(t *testing.T) {
+	saveGlobals(t)
+	s, _ := newTestStore(t)
+	store = s
+
+	long := strings.Repeat("x", ceremonyTextLimit+50)
+	emitLifecycleCeremony(events.CeremonyTopicPheromoneEmit, events.CeremonyPayload{
+		PheromoneType: "FOCUS",
+		Strength:      0.8,
+		Status:        "created",
+		Message:       long,
+	}, "unit-test")
+
+	lines, err := s.ReadJSONL("event-bus.jsonl")
+	if err != nil {
+		t.Fatalf("read event bus: %v", err)
+	}
+	if len(lines) != 1 {
+		t.Fatalf("persisted events = %d, want 1", len(lines))
+	}
+	var persisted events.Event
+	if err := json.Unmarshal(lines[0], &persisted); err != nil {
+		t.Fatalf("unmarshal persisted event: %v", err)
+	}
+	if persisted.Topic != events.CeremonyTopicPheromoneEmit {
+		t.Fatalf("topic = %q, want %q", persisted.Topic, events.CeremonyTopicPheromoneEmit)
+	}
+	if persisted.Source != "unit-test" {
+		t.Fatalf("source = %q, want unit-test", persisted.Source)
+	}
+	var payload events.CeremonyPayload
+	if err := json.Unmarshal(persisted.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.PheromoneType != "FOCUS" || payload.Status != "created" || payload.Strength != 0.8 {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if len(payload.Message) > ceremonyTextLimit {
+		t.Fatalf("message was not trimmed: %d", len(payload.Message))
+	}
+}
+
+func TestPheromoneWriteEmitsCeremonyEvent(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+	s, _ := newTestStore(t)
+	store = s
+	var buf bytes.Buffer
+	stdout = &buf
+
+	rootCmd.SetArgs([]string{"pheromone-write", "--type", "FOCUS", "--content", "Surface lifecycle context", "--strength", "0.75"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("pheromone-write returned error: %v", err)
+	}
+
+	lines, err := s.ReadJSONL("event-bus.jsonl")
+	if err != nil {
+		t.Fatalf("read event bus: %v", err)
+	}
+	if len(lines) != 1 {
+		t.Fatalf("persisted events = %d, want 1", len(lines))
+	}
+	var persisted events.Event
+	if err := json.Unmarshal(lines[0], &persisted); err != nil {
+		t.Fatalf("unmarshal persisted event: %v", err)
+	}
+	if persisted.Topic != events.CeremonyTopicPheromoneEmit {
+		t.Fatalf("topic = %q, want %q", persisted.Topic, events.CeremonyTopicPheromoneEmit)
+	}
+	var payload events.CeremonyPayload
+	if err := json.Unmarshal(persisted.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.PheromoneType != "FOCUS" || payload.Status != "created" || payload.Strength != 0.75 {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if payload.Message != "Surface lifecycle context" {
+		t.Fatalf("message = %q", payload.Message)
+	}
+}
+
+func TestSealEmitsChamberCeremonyEvent(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+	s, _ := newTestStore(t)
+	store = s
+	var buf bytes.Buffer
+	stdout = &buf
+
+	goal := "Seal ceremony events"
+	state := colony.ColonyState{
+		Version:      "3.0",
+		Goal:         &goal,
+		State:        colony.StateREADY,
+		CurrentPhase: 1,
+		Plan: colony.Plan{Phases: []colony.Phase{{
+			ID:     1,
+			Name:   "Complete work",
+			Status: colony.PhaseCompleted,
+		}}},
+	}
+	if err := s.SaveJSON("COLONY_STATE.json", state); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"seal"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("seal returned error: %v", err)
+	}
+
+	lines, err := s.ReadJSONL("event-bus.jsonl")
+	if err != nil {
+		t.Fatalf("read event bus: %v", err)
+	}
+	if len(lines) != 1 {
+		t.Fatalf("persisted events = %d, want 1", len(lines))
+	}
+	var persisted events.Event
+	if err := json.Unmarshal(lines[0], &persisted); err != nil {
+		t.Fatalf("unmarshal persisted event: %v", err)
+	}
+	if persisted.Topic != events.CeremonyTopicChamberSeal {
+		t.Fatalf("topic = %q, want %q", persisted.Topic, events.CeremonyTopicChamberSeal)
+	}
+	var payload events.CeremonyPayload
+	if err := json.Unmarshal(persisted.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Status != "sealed" || payload.PhaseName != "Crowned Anthill" || payload.Completed != 1 || payload.Total != 1 {
+		t.Fatalf("payload = %+v", payload)
 	}
 }
 

--- a/cmd/ceremony_emitter_test.go
+++ b/cmd/ceremony_emitter_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/calcosmic/Aether/pkg/codex"
 	"github.com/calcosmic/Aether/pkg/colony"
 	"github.com/calcosmic/Aether/pkg/events"
 )
@@ -253,6 +255,92 @@ func TestSealEmitsChamberCeremonyEvent(t *testing.T) {
 	}
 }
 
+func TestPlanEmitsLifecycleCeremonyEvents(t *testing.T) {
+	saveGlobals(t)
+	s, root := newTestStore(t)
+	store = s
+	goal := "Plan ceremony events"
+	state := colony.ColonyState{
+		Version:      "3.0",
+		Goal:         &goal,
+		State:        colony.StateREADY,
+		CurrentPhase: 0,
+	}
+	if err := s.SaveJSON("COLONY_STATE.json", state); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	if _, err := runCodexPlanWithOptions(root, codexPlanOptions{Synthetic: true}); err != nil {
+		t.Fatalf("plan returned error: %v", err)
+	}
+
+	assertCeremonyTopics(t, readPersistedCeremonyEvents(t),
+		events.CeremonyTopicPlanWaveStart,
+		events.CeremonyTopicPlanSpawn,
+		events.CeremonyTopicPlanWaveEnd,
+	)
+}
+
+func TestColonizeEmitsLifecycleCeremonyEvents(t *testing.T) {
+	saveGlobals(t)
+	s, root := newTestStore(t)
+	store = s
+
+	if _, err := runCodexColonizeWithOptions(root, codexColonizeOptions{}); err != nil {
+		t.Fatalf("colonize returned error: %v", err)
+	}
+
+	assertCeremonyTopics(t, readPersistedCeremonyEvents(t),
+		events.CeremonyTopicColonizeWaveStart,
+		events.CeremonyTopicColonizeSpawn,
+		events.CeremonyTopicColonizeWaveEnd,
+	)
+}
+
+func TestContinueEmitsLifecycleCeremonyEvents(t *testing.T) {
+	saveGlobals(t)
+	s, root := newTestStore(t)
+	store = s
+	now := time.Now().UTC()
+	goal := "Continue ceremony events"
+	taskID := "1.1"
+	state := colony.ColonyState{
+		Version:        "3.0",
+		Goal:           &goal,
+		State:          colony.StateBUILT,
+		CurrentPhase:   1,
+		BuildStartedAt: &now,
+		Plan: colony.Plan{Phases: []colony.Phase{{
+			ID:     1,
+			Name:   "Continue hooks",
+			Status: colony.PhaseInProgress,
+			Tasks:  []colony.Task{{ID: &taskID, Goal: "Emit continue ceremony events", Status: colony.TaskPending}},
+		}}},
+	}
+	if err := s.SaveJSON("COLONY_STATE.json", state); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	seedContinueBuildPacket(t, s.BasePath(), 1, "Continue hooks", goal, []codexBuildDispatch{{
+		Stage:  "implementation",
+		Caste:  "builder",
+		Name:   "Mason-67",
+		TaskID: taskID,
+		Task:   "Emit continue ceremony events",
+		Status: "completed",
+	}})
+	newCodexWorkerInvoker = func() codex.WorkerInvoker { return &continueUnavailableInvoker{} }
+
+	if _, _, _, _, _, _, err := runCodexContinue(root, codexContinueOptions{}); err != nil {
+		t.Fatalf("continue returned error: %v", err)
+	}
+
+	assertCeremonyTopics(t, readPersistedCeremonyEvents(t),
+		events.CeremonyTopicContinueWaveStart,
+		events.CeremonyTopicContinueSpawn,
+		events.CeremonyTopicContinueWaveEnd,
+	)
+}
+
 func TestActiveBuildCeremonyScopeRestoresPreviousEmitter(t *testing.T) {
 	saveGlobals(t)
 	outer := &buildCeremonyEmitter{phaseID: 1, phaseName: "outer"}
@@ -273,6 +361,36 @@ func TestActiveBuildCeremonyScopeRestoresPreviousEmitter(t *testing.T) {
 	restoreOuter()
 	if currentBuildCeremony() != nil {
 		t.Fatal("active emitter was not cleared")
+	}
+}
+
+func readPersistedCeremonyEvents(t *testing.T) []events.Event {
+	t.Helper()
+	lines, err := store.ReadJSONL("event-bus.jsonl")
+	if err != nil {
+		t.Fatalf("read event bus: %v", err)
+	}
+	persisted := make([]events.Event, 0, len(lines))
+	for _, line := range lines {
+		var evt events.Event
+		if err := json.Unmarshal(line, &evt); err != nil {
+			t.Fatalf("unmarshal event: %v", err)
+		}
+		persisted = append(persisted, evt)
+	}
+	return persisted
+}
+
+func assertCeremonyTopics(t *testing.T, persisted []events.Event, wants ...string) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, evt := range persisted {
+		seen[evt.Topic] = true
+	}
+	for _, want := range wants {
+		if !seen[want] {
+			t.Fatalf("missing ceremony topic %q in %+v", want, persisted)
+		}
 	}
 }
 

--- a/cmd/codex_colonize.go
+++ b/cmd/codex_colonize.go
@@ -167,6 +167,7 @@ func runCodexColonizeWithOptions(root string, opts codexColonizeOptions) (map[st
 			return nil, fmt.Errorf("failed to update surveyor completion: %w", err)
 		}
 	}
+	emitColonizeCeremonyDispatchSequence("aether-colonize", dispatches)
 
 	surveyedAt := time.Now().UTC().Format(time.RFC3339)
 	if err := updateSurveyState(surveyedAt, len(surveyFiles)); err != nil {

--- a/cmd/codex_continue.go
+++ b/cmd/codex_continue.go
@@ -268,12 +268,12 @@ func runCodexContinue(root string, options codexContinueOptions) (map[string]int
 		_ = store.SaveJSON(
 			filepath.ToSlash(filepath.Join("build", fmt.Sprintf("phase-%d", phase.ID), "continue.json")),
 			codexContinueReport{
-				Phase:         phase.ID,
-				GeneratedAt:   now.Format(time.RFC3339),
-				Summary:       abandonedSummary,
-				Recovery:      recovery,
-				Advanced:      false,
-				Completed:     false,
+				Phase:       phase.ID,
+				GeneratedAt: now.Format(time.RFC3339),
+				Summary:     abandonedSummary,
+				Recovery:    recovery,
+				Advanced:    false,
+				Completed:   false,
 			},
 		)
 		finishRuntimeSpawnRun(runHandle, "blocked-abandoned", now)
@@ -349,6 +349,7 @@ func runCodexContinue(root string, options codexContinueOptions) (map[string]int
 		}
 		continueReportRel := filepath.ToSlash(filepath.Join("build", fmt.Sprintf("phase-%d", phase.ID), "continue.json"))
 		workerFlow := continueWorkerFlowWithWatcher(nil, watcherFlow)
+		emitContinueCeremonyFlowSequence("aether-continue", phase, workerFlow)
 		nextCommand := continueNextCommandForAssessment(assessment)
 		_ = store.SaveJSON(continueReportRel, codexContinueReport{
 			Phase:              phase.ID,
@@ -409,6 +410,7 @@ func runCodexContinue(root string, options codexContinueOptions) (map[string]int
 		}
 		continueReportRel := filepath.ToSlash(filepath.Join("build", fmt.Sprintf("phase-%d", phase.ID), "continue.json"))
 		workerFlow := continueWorkerFlowWithWatcher(review.Workers, watcherFlow)
+		emitContinueCeremonyFlowSequence("aether-continue", phase, workerFlow)
 		nextCommand := continueNextCommandForAssessment(assessment)
 		_ = store.SaveJSON(continueReportRel, codexContinueReport{
 			Phase:              phase.ID,
@@ -528,6 +530,7 @@ func runCodexContinue(root string, options codexContinueOptions) (map[string]int
 	if err := applyCodexContinueWorkerClosures(closedWorkerDetails); err != nil {
 		return nil, state, phase, nil, &housekeeping, false, err
 	}
+	emitContinueCeremonyFlowSequence("aether-continue", phase, workerFlow)
 	updated.Events = append(updated.Events, continueWorkerFlowEvents(now, workerFlow)...)
 	// Persist side-effect events (review, housekeeping) into colony state.
 	// This is a best-effort append; the core advancement was already committed.

--- a/cmd/codex_continue_finalize.go
+++ b/cmd/codex_continue_finalize.go
@@ -374,6 +374,7 @@ func finalizeBlockedExternalContinue(state colony.ColonyState, phase colony.Phas
 	if err := store.SaveJSON("COLONY_STATE.json", blockedState); err != nil {
 		return nil, state, fmt.Errorf("failed to save colony state: %w", err)
 	}
+	emitContinueCeremonyFlowSequence("aether-continue-finalize", phase, workerFlow)
 	updateSessionSummary("continue-finalize", nextCommand, summary)
 	result := map[string]interface{}{
 		"advanced":            false,
@@ -467,6 +468,7 @@ func advanceExternalContinue(root string, state colony.ColonyState, phase colony
 	if err := applyCodexContinueWorkerClosures(closedWorkerDetails); err != nil {
 		return nil, state, nil, &housekeeping, final, err
 	}
+	emitContinueCeremonyFlowSequence("aether-continue-finalize", phase, fullWorkerFlow)
 	updated.Events = append(updated.Events, continueWorkerFlowEvents(now, fullWorkerFlow)...)
 	_ = store.SaveJSON("COLONY_STATE.json", updated)
 

--- a/cmd/codex_plan.go
+++ b/cmd/codex_plan.go
@@ -342,6 +342,7 @@ func runCodexPlanWithOptions(root string, opts codexPlanOptions) (map[string]int
 			return nil, fmt.Errorf("failed to update planning completion: %w", err)
 		}
 	}
+	emitPlanCeremonyDispatchSequence("aether-plan", dispatches)
 
 	now := time.Now().UTC()
 	state.State = colony.StateREADY

--- a/cmd/codex_plan_finalize.go
+++ b/cmd/codex_plan_finalize.go
@@ -206,6 +206,7 @@ func runCodexPlanFinalize(root string, completion codexExternalPlanCompletion) (
 	if err := store.SaveJSON("COLONY_STATE.json", updatedState); err != nil {
 		return nil, fmt.Errorf("failed to save colony state: %w", err)
 	}
+	emitPlanCeremonyDispatchSequence("aether-plan-finalize", dispatches)
 
 	nextPhase := firstBuildablePhase(phases)
 	nextCommand := "aether build 1"

--- a/cmd/codex_workflow_cmds.go
+++ b/cmd/codex_workflow_cmds.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/calcosmic/Aether/pkg/colony"
+	"github.com/calcosmic/Aether/pkg/events"
 	"github.com/spf13/cobra"
 )
 
@@ -242,6 +243,14 @@ var sealCmd = &cobra.Command{
 			outputError(2, fmt.Sprintf("failed to write %s: %v", summaryPath, err), nil)
 			return nil
 		}
+		emitLifecycleCeremony(events.CeremonyTopicChamberSeal, events.CeremonyPayload{
+			Phase:     state.CurrentPhase,
+			PhaseName: "Crowned Anthill",
+			Status:    "sealed",
+			Message:   "Colony sealed at Crowned Anthill",
+			Completed: completedPhaseCount(state),
+			Total:     len(state.Plan.Phases),
+		}, "aether-seal")
 		updateSessionSummary("seal", "aether entomb", "Colony sealed")
 
 		result := map[string]interface{}{

--- a/cmd/pheromone_write.go
+++ b/cmd/pheromone_write.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/calcosmic/Aether/pkg/colony"
+	"github.com/calcosmic/Aether/pkg/events"
 	"github.com/spf13/cobra"
 )
 
@@ -184,6 +185,16 @@ var pheromoneWriteCmd = &cobra.Command{
 				_ = tracer.LogPheromone(*state.RunID, sigType, "pheromone-write")
 			}
 		}
+		status := "created"
+		if replaced {
+			status = "reinforced"
+		}
+		emitLifecycleCeremony(events.CeremonyTopicPheromoneEmit, events.CeremonyPayload{
+			PheromoneType: sigType,
+			Strength:      strength,
+			Status:        status,
+			Message:       extractText(signal.Content),
+		}, "aether-pheromone")
 
 		outputOK(map[string]interface{}{
 			"created":  true,

--- a/pkg/events/ceremony.go
+++ b/pkg/events/ceremony.go
@@ -3,14 +3,23 @@ package events
 import "encoding/json"
 
 const (
-	CeremonyTopicBuildPrewave   = "ceremony.build.prewave"
-	CeremonyTopicBuildWaveStart = "ceremony.build.wave.start"
-	CeremonyTopicBuildSpawn     = "ceremony.build.spawn"
-	CeremonyTopicBuildToolUse   = "ceremony.build.tool_use"
-	CeremonyTopicBuildWaveEnd   = "ceremony.build.wave.end"
-	CeremonyTopicPheromoneEmit  = "ceremony.pheromone.emit"
-	CeremonyTopicSkillActivate  = "ceremony.skill.activate"
-	CeremonyTopicChamberSeal    = "ceremony.chamber.seal"
+	CeremonyTopicBuildPrewave      = "ceremony.build.prewave"
+	CeremonyTopicBuildWaveStart    = "ceremony.build.wave.start"
+	CeremonyTopicBuildSpawn        = "ceremony.build.spawn"
+	CeremonyTopicBuildToolUse      = "ceremony.build.tool_use"
+	CeremonyTopicBuildWaveEnd      = "ceremony.build.wave.end"
+	CeremonyTopicPlanWaveStart     = "ceremony.plan.wave.start"
+	CeremonyTopicPlanSpawn         = "ceremony.plan.spawn"
+	CeremonyTopicPlanWaveEnd       = "ceremony.plan.wave.end"
+	CeremonyTopicColonizeWaveStart = "ceremony.colonize.wave.start"
+	CeremonyTopicColonizeSpawn     = "ceremony.colonize.spawn"
+	CeremonyTopicColonizeWaveEnd   = "ceremony.colonize.wave.end"
+	CeremonyTopicContinueWaveStart = "ceremony.continue.wave.start"
+	CeremonyTopicContinueSpawn     = "ceremony.continue.spawn"
+	CeremonyTopicContinueWaveEnd   = "ceremony.continue.wave.end"
+	CeremonyTopicPheromoneEmit     = "ceremony.pheromone.emit"
+	CeremonyTopicSkillActivate     = "ceremony.skill.activate"
+	CeremonyTopicChamberSeal       = "ceremony.chamber.seal"
 )
 
 // CeremonyPayload is the shared event shape consumed by the bundled narrator.
@@ -55,6 +64,15 @@ func CeremonyTopics() []string {
 		CeremonyTopicBuildSpawn,
 		CeremonyTopicBuildToolUse,
 		CeremonyTopicBuildWaveEnd,
+		CeremonyTopicPlanWaveStart,
+		CeremonyTopicPlanSpawn,
+		CeremonyTopicPlanWaveEnd,
+		CeremonyTopicColonizeWaveStart,
+		CeremonyTopicColonizeSpawn,
+		CeremonyTopicColonizeWaveEnd,
+		CeremonyTopicContinueWaveStart,
+		CeremonyTopicContinueSpawn,
+		CeremonyTopicContinueWaveEnd,
 		CeremonyTopicPheromoneEmit,
 		CeremonyTopicSkillActivate,
 		CeremonyTopicChamberSeal,


### PR DESCRIPTION
## Summary

Continues the v1.6 ceremony revival after PR #6 and PR #7 merged.

- Adds a generic `emitLifecycleCeremony` path for non-build ceremony events backed by `event-bus.jsonl`.
- Emits `ceremony.pheromone.emit` from `pheromone-write`, including signal type, strength, created/reinforced status, and sanitized signal text.
- Emits `ceremony.chamber.seal` from `aether seal`, including Crowned Anthill status and completed/total phase counts.
- Adds `ceremony.plan.*`, `ceremony.colonize.*`, and `ceremony.continue.*` wave/spawn topics.
- Persists retrospective wave start/spawn/wave end ceremony sequences from `plan`, `plan-finalize`, `colonize`, `continue`, and `continue-finalize` using Go-owned lifecycle results.
- Updates the tracked ceremony handoff/context for PR #8 and the Phase 6 lifecycle event slices.

## Validation

- `go test ./cmd -run 'TestLifecycleCeremonyPersistsTrimmedEvent|TestPheromoneWriteEmitsCeremonyEvent|TestSealEmitsChamberCeremonyEvent|TestBuildCeremonyEmitter' -count=1`
- `go test ./cmd -run 'Test.*Ceremony|TestCeremony|TestPlanEmitsLifecycleCeremonyEvents|TestColonizeEmitsLifecycleCeremonyEvents|TestContinueEmitsLifecycleCeremonyEvents' -count=1`
- `go test ./cmd -count=1`
- `git diff --check`
- `go test ./... -count=1 -timeout 300s`
- `go vet ./...`

## Remaining Work

- Continue Phase 6 worker/skill context events, especially `ceremony.skill.activate` from real skill activation points.
- Add remaining graveyard/entomb-style lifecycle context where Go-owned state transitions exist.
- True Claude/OpenCode Task-tool wrapper smoke remains pending outside Codex.
