### PR TITLE
[codex] Emit skill activation ceremony events

### DIFF
--- a/.aether/CONTEXT.md
+++ b/.aether/CONTEXT.md
@@ -8,7 +8,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Last Updated** | 2026-04-24T12:14:23Z |
+| **Last Updated** | 2026-04-24T12:22:11Z |
 | **Current Phase** | 1 |
 | **Phase Name** | Assumptions and gap audit |
 | **Phase Status** | ready |
@@ -78,6 +78,8 @@ Phase 6 first Go-backed lifecycle ceremony slice is complete in the working tree
 
 Phase 6 plan/colonize/continue ceremony slice is complete in the working tree: `pkg/events/ceremony.go` defines `ceremony.plan.*`, `ceremony.colonize.*`, and `ceremony.continue.*` wave/spawn topics; `cmd/ceremony_emitter.go` has a shared lifecycle sequence emitter; `plan`, `plan-finalize`, `colonize`, `continue`, and `continue-finalize` persist retrospective wave start/spawn/wave end events from Go-owned command results. Focused ceremony tests, `go test ./cmd -count=1`, `go test ./... -count=1 -timeout 300s`, `go vet ./...`, and `git diff --check` passed.
 
+Phase 6 skill activation ceremony slice is complete in the working tree: `resolveSkillSection` now emits `ceremony.skill.activate` for each matched injected skill, using the existing Go-owned skill resolver as the source of truth. Focused ceremony tests, `go test ./cmd -count=1`, `go test ./... -count=1 -timeout 300s`, `go vet ./...`, and `git diff --check` passed.
+
 ---
 
 ## Active Constraints (REDIRECT Signals)
@@ -144,13 +146,15 @@ Phase 6 plan/colonize/continue ceremony slice is complete in the working tree: `
 - 2026-04-24T12:00:05Z|phase6_lifecycle_verified|test|Pheromone/chamber ceremony event slice passed focused, full cmd, full repo, vet, and whitespace checks
 - 2026-04-24T12:14:23Z|phase6_wave_events|build|Plan, colonize, and continue commands now persist ceremony wave/spawn event sequences from Go-owned lifecycle results
 - 2026-04-24T12:14:23Z|phase6_wave_events_verified|test|Lifecycle wave event slice passed focused ceremony tests, full cmd, full repo, vet, and whitespace checks
+- 2026-04-24T12:22:11Z|phase6_skill_events|build|Go-owned skill injection now persists ceremony.skill.activate events for matched injected skills
+- 2026-04-24T12:22:11Z|phase6_skill_events_verified|test|Skill activation event slice passed focused ceremony tests, full cmd, full repo, vet, and whitespace checks
 
 ---
 
 ## Next Steps
 
-1. Commit/push the Phase 6 plan/colonize/continue lifecycle wave event slice to PR #8
-2. Continue Phase 6 worker/skill context events, especially `ceremony.skill.activate` from real skill activation points
+1. Commit/push the Phase 6 skill activation event slice to PR #8
+2. Continue remaining Phase 6 graveyard/entomb and QUEEN/Hive/midden context events where Go-owned state transitions exist
 3. Run true Claude/OpenCode build wrapper smoke with platform Task-tool agents when available
 4. Keep Go as state/event source of truth; wrappers own Task-tool spawning
 

--- a/.aether/docs/ceremony-revival-v1.6-handoff.md
+++ b/.aether/docs/ceremony-revival-v1.6-handoff.md
@@ -1,6 +1,6 @@
 # Ceremony Revival v1.6 Handoff
 
-Last updated: 2026-04-24T12:14:23Z
+Last updated: 2026-04-24T12:22:11Z
 
 Branch: `codex/ceremony-lifecycle-events-v16`
 Base: `origin/main` after merged PR #7
@@ -49,7 +49,7 @@ committed directly while the persisted colony lifecycle was not advanced through
 | Phase 3: rolling activity display | Implemented foundation | `.aether/ts/narrator.ts`, multi-wave activity tests, `dist/narrator.js` | TTY live redraw/debounce deferred until real terminal contract is clear |
 | Phase 4: build subagent bridge | Implemented for wrappers | `build --plan-only`, `build-finalize`, manifest `execution_plan`, Claude/OpenCode build wrappers, wrapper contract tests | Live platform smoke and any future specialist prompt polish |
 | Phase 5: continue and plan orchestration | Implemented for wrappers | `continue --plan-only`, `continue-finalize`, `plan --plan-only`, `plan-finalize`, wrapper contract tests | Live platform smoke; stall/confidence ceremony polish |
-| Phase 6: full lifecycle ceremony and skills | Partially implemented | Build ceremony emits from Go; TS renders generic lifecycle stages and context notices; Go emits pheromone/chamber plus plan/colonize/continue wave events | Emit skill activation and remaining QUEEN/Hive/midden/graveyard context from real state |
+| Phase 6: full lifecycle ceremony and skills | Partially implemented | Build ceremony emits from Go; TS renders generic lifecycle stages and context notices; Go emits pheromone/chamber plus plan/colonize/continue wave events and skill activation notices | Emit remaining QUEEN/Hive/midden/graveyard context from real state |
 | Phase 7: parity verification and release | Not done | Release/rollback notes exist | Cross-platform smoke, install/update release checks, PR review, release hardening |
 
 Safe continuation point: PR #6 and PR #7 are merged. PR #8 is still open as a
@@ -59,7 +59,8 @@ GitHub because PR #7 was merged without deleting its source branch. Go-side
 wrapper smoke passed for `build 1 --plan-only`; true Claude/OpenCode Task-tool
 smoke remains pending because Codex cannot execute those platform Task-tool
 wrappers directly. The current working-tree slice continues Phase 6 Go-backed
-lifecycle ceremony emission for plan, colonize, and continue wave events.
+lifecycle ceremony emission for plan, colonize, continue wave events, and
+skill activation notices.
 
 ## Already Shipped On This Branch
 
@@ -1057,6 +1058,35 @@ Verification run:
 - `go test ./... -count=1 -timeout 300s`
 - `go vet ./...`
 
+## Working Tree Slice: Phase 6 Skill Activation Events
+
+Date: 2026-04-24
+
+This slice makes matched injected skills visible as ceremony context.
+
+Changed files:
+
+- `cmd/ceremony_emitter.go`
+- `cmd/codex_build.go`
+- `cmd/ceremony_emitter_test.go`
+
+Implemented behavior:
+
+- `resolveSkillSection` now emits `ceremony.skill.activate` for every matched
+  skill it injects into worker context.
+- Skill event emission uses the existing Go-owned skill resolver as the source
+  of truth; no separate skill matching path was added.
+- The event payload includes the skill name, `activated` status, worker role
+  context, and task text.
+
+Verification run:
+
+- `go test ./cmd -run 'TestResolveSkillSectionEmitsSkillActivationCeremony|Test.*Ceremony|TestCeremony' -count=1`
+- `git diff --check`
+- `go test ./cmd -count=1`
+- `go test ./... -count=1 -timeout 300s`
+- `go vet ./...`
+
 ## Release And Rollback
 
 Rollback controls:
@@ -1077,10 +1107,11 @@ Before release:
 
 ## Current Next Step
 
-Next, commit and push the Phase 6 plan/colonize/continue wave event slice to
-PR #8, then continue with visible worker/skill context events. Platform
-Task-tool smoke is still required when Claude or OpenCode is available. The
-preconditions now satisfied are:
+Next, commit and push the Phase 6 skill activation event slice to PR #8, then
+continue with remaining graveyard/entomb and QUEEN/Hive/midden context events
+where Go-owned state transitions exist. Platform Task-tool smoke is still
+required when Claude or OpenCode is available. The preconditions now satisfied
+are:
 
 1. hub fallback smoke passed in a temporary HOME;
 2. TTY live redraw is consciously deferred;
@@ -1098,4 +1129,6 @@ preconditions now satisfied are:
 10. Phase 6 pheromone/chamber event hooks are implemented and verified;
 11. Phase 6 plan/colonize/continue wave event hooks are implemented in the
     working tree with focused, full cmd, full repo, vet, and whitespace checks
-    passing.
+    passing;
+12. Phase 6 skill activation event hooks are implemented in the working tree
+    with focused, full cmd, full repo, vet, and whitespace checks passing.

--- a/cmd/ceremony_emitter.go
+++ b/cmd/ceremony_emitter.go
@@ -326,6 +326,30 @@ func emitContinueCeremonyFlowSequence(source string, phase colony.Phase, workerF
 	}, source, "continue", phase.ID, phase.Name, steps)
 }
 
+func emitSkillActivationCeremonies(result skillInjectResult) {
+	if result.SkillCount == 0 {
+		return
+	}
+	entries := append([]skillResolvedEntry{}, result.ColonySkills...)
+	entries = append(entries, result.DomainSkills...)
+	emitted := 0
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.Name) == "" {
+			continue
+		}
+		emitLifecycleCeremony(events.CeremonyTopicSkillActivate, events.CeremonyPayload{
+			Skill:   entry.Name,
+			Status:  "activated",
+			Task:    result.Task,
+			Message: fmt.Sprintf("matched for %s worker context", strings.TrimSpace(result.Role)),
+		}, "aether-skill")
+		emitted++
+		if emitted >= result.SkillCount {
+			return
+		}
+	}
+}
+
 func continueCeremonyWaveForStage(stage string) int {
 	switch strings.ToLower(strings.TrimSpace(stage)) {
 	case "verification":

--- a/cmd/ceremony_emitter_test.go
+++ b/cmd/ceremony_emitter_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -339,6 +341,43 @@ func TestContinueEmitsLifecycleCeremonyEvents(t *testing.T) {
 		events.CeremonyTopicContinueSpawn,
 		events.CeremonyTopicContinueWaveEnd,
 	)
+}
+
+func TestResolveSkillSectionEmitsSkillActivationCeremony(t *testing.T) {
+	saveGlobals(t)
+	s, _ := newTestStore(t)
+	store = s
+
+	tmpDir := t.TempDir()
+	hubDir := tmpDir + "/hub"
+	skillsDir := hubDir + "/skills/colony/test-skill"
+	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+		t.Fatalf("failed to create skill dir: %v", err)
+	}
+	skillContent := "---\nname: test-skill\ntype: colony\ncategory: testing\nagent_roles:\n  - builder\n---\nThis is the test skill content."
+	if err := os.WriteFile(filepath.Join(skillsDir, "SKILL.md"), []byte(skillContent), 0644); err != nil {
+		t.Fatalf("failed to write skill: %v", err)
+	}
+	os.Setenv("AETHER_HUB_DIR", hubDir)
+	t.Cleanup(func() { os.Unsetenv("AETHER_HUB_DIR") })
+
+	section := resolveSkillSection("builder", "testing task")
+	if section == "" {
+		t.Fatal("expected matched skill section")
+	}
+
+	persisted := readPersistedCeremonyEvents(t)
+	assertCeremonyTopics(t, persisted, events.CeremonyTopicSkillActivate)
+	var payload events.CeremonyPayload
+	if err := json.Unmarshal(persisted[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Skill != "test-skill" || payload.Status != "activated" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if !strings.Contains(payload.Message, "builder") {
+		t.Fatalf("message = %q, want builder context", payload.Message)
+	}
 }
 
 func TestActiveBuildCeremonyScopeRestoresPreviousEmitter(t *testing.T) {

--- a/cmd/codex_build.go
+++ b/cmd/codex_build.go
@@ -1390,7 +1390,9 @@ func resolveSkillSectionResult(caste, task string) skillInjectResult {
 // resolveSkillSection matches skills for the given role and task through the
 // shared runtime resolver and returns the rendered markdown section.
 func resolveSkillSection(caste, task string) string {
-	return resolveSkillSectionResult(caste, task).SkillSection
+	result := resolveSkillSectionResult(caste, task)
+	emitSkillActivationCeremonies(result)
+	return result.SkillSection
 }
 
 // resolvePheromoneSection extracts active pheromone signals, groups them by


### PR DESCRIPTION
## Summary

Continues Phase 6 after PR #8 merged.

- Emits `ceremony.skill.activate` from `resolveSkillSection` for each matched skill injected into worker context.
- Uses the existing Go-owned skill resolver as the source of truth; no parallel skill matching path was added.
- Updates the tracked ceremony context/handoff with the PR #8 merge race and the skill activation slice.

## Validation

- `go test ./cmd -run 'TestResolveSkillSectionEmitsSkillActivationCeremony|Test.*Ceremony|TestCeremony' -count=1`
- `git diff --check`
- `go test ./cmd -count=1`
- `go test ./... -count=1 -timeout 300s`
- `go vet ./...`

## Remaining Work

- Add remaining graveyard/entomb and QUEEN/Hive/midden context events where Go-owned state transitions exist.
- True Claude/OpenCode Task-tool wrapper smoke remains pending outside Codex.

## Note

PR #8 was merged at `b0daef87` before the skill commit landed on its source branch, so this PR carries only the post-merge skill-event delta from `origin/main`.
