### PR TITLE
Emit lifecycle context ceremony events

### DIFF
--- a/.aether/CONTEXT.md
+++ b/.aether/CONTEXT.md
@@ -70,7 +70,7 @@ TypeScript lifecycle-context rendering slice is in the working tree: `.aether/ts
 
 Broad checkpoint verification passed on 2026-04-24T11:27:54Z: TS install/typecheck/test/build, `gofmt`, `git diff --check`, `go test ./cmd -count=1`, `go test ./... -count=1 -timeout 300s`, and `go vet ./...`.
 
-GitHub PR status: PR #5, PR #6, and PR #7 are merged. PR #8 is still open as a draft for `codex/ceremony-lifecycle-events-v16`; it is not on `main` yet. The old `codex/ceremony-narrator-foundation-v16` branch still appears on GitHub because PR #7 was merged but the source branch was not deleted.
+GitHub PR status: PR #5, PR #6, PR #7, PR #8, and PR #9 are merged. PR #10 is open, clean, and mergeable for `codex/ceremony-context-events-v16`. The old `codex/ceremony-narrator-foundation-v16` branch still appears on GitHub because PR #7 was merged but the source branch was not deleted.
 
 Go-side wrapper smoke passed with `AETHER_OUTPUT_MODE=json go run ./cmd/aether build 1 --plan-only`: the standard-depth manifest emitted builder execution wave 11, Probe wave 12, and Watcher wave 13. True Claude/OpenCode Task-tool smoke remains pending because Codex cannot execute those platform wrapper tools directly.
 
@@ -79,6 +79,10 @@ Phase 6 first Go-backed lifecycle ceremony slice is complete in the working tree
 Phase 6 plan/colonize/continue ceremony slice is complete in the working tree: `pkg/events/ceremony.go` defines `ceremony.plan.*`, `ceremony.colonize.*`, and `ceremony.continue.*` wave/spawn topics; `cmd/ceremony_emitter.go` has a shared lifecycle sequence emitter; `plan`, `plan-finalize`, `colonize`, `continue`, and `continue-finalize` persist retrospective wave start/spawn/wave end events from Go-owned command results. Focused ceremony tests, `go test ./cmd -count=1`, `go test ./... -count=1 -timeout 300s`, `go vet ./...`, and `git diff --check` passed.
 
 Phase 6 skill activation ceremony slice is complete in the working tree: `resolveSkillSection` now emits `ceremony.skill.activate` for each matched injected skill, using the existing Go-owned skill resolver as the source of truth. Focused ceremony tests, `go test ./cmd -count=1`, `go test ./... -count=1 -timeout 300s`, `go vet ./...`, and `git diff --check` passed.
+
+Phase 6 lifecycle context event slice is complete in the working tree on `codex/ceremony-context-events-v16`: entomb, midden-write, queen-promote, hive-store, and hive-promote now emit Go-owned ceremony context events (`ceremony.chamber.entomb`, `ceremony.midden.record`, `ceremony.queen.promote`, `ceremony.hive.store`, `ceremony.hive.promote`). The TypeScript narrator renders these as generic Context notices. Focused Go ceremony tests, `npm run typecheck --prefix .aether/ts`, `npm test --prefix .aether/ts`, `go test ./cmd -count=1`, `go test ./... -count=1 -timeout 300s`, `go vet ./...`, and `git diff --check` passed.
+
+PR #10 URL: `https://github.com/calcosmic/Aether/pull/10`
 
 ---
 
@@ -148,15 +152,17 @@ Phase 6 skill activation ceremony slice is complete in the working tree: `resolv
 - 2026-04-24T12:14:23Z|phase6_wave_events_verified|test|Lifecycle wave event slice passed focused ceremony tests, full cmd, full repo, vet, and whitespace checks
 - 2026-04-24T12:22:11Z|phase6_skill_events|build|Go-owned skill injection now persists ceremony.skill.activate events for matched injected skills
 - 2026-04-24T12:22:11Z|phase6_skill_events_verified|test|Skill activation event slice passed focused ceremony tests, full cmd, full repo, vet, and whitespace checks
+- 2026-04-24T12:38:00Z|phase6_context_events|build|Entomb, midden, QUEEN, and Hive commands now persist lifecycle context ceremony events
+- 2026-04-24T12:38:00Z|phase6_context_events_verified|test|Context event slice passed focused Go and TS narrator checks plus full cmd, full repo, vet, and whitespace gates
+- 2026-04-24T12:38:25Z|pr_opened|github|PR #10 opened for lifecycle context ceremony events; branch is clean and mergeable
 
 ---
 
 ## Next Steps
 
-1. Commit/push the Phase 6 skill activation event slice to PR #8
-2. Continue remaining Phase 6 graveyard/entomb and QUEEN/Hive/midden context events where Go-owned state transitions exist
-3. Run true Claude/OpenCode build wrapper smoke with platform Task-tool agents when available
-4. Keep Go as state/event source of truth; wrappers own Task-tool spawning
+1. Review/merge PR #10
+2. Run true Claude/OpenCode build wrapper smoke with platform Task-tool agents when available
+3. Keep Go as state/event source of truth; wrappers own Task-tool spawning
 
 ---
 

--- a/.aether/docs/ceremony-revival-v1.6-handoff.md
+++ b/.aether/docs/ceremony-revival-v1.6-handoff.md
@@ -1,12 +1,11 @@
 # Ceremony Revival v1.6 Handoff
 
-Last updated: 2026-04-24T12:22:11Z
+Last updated: 2026-04-24T12:38:25Z
 
-Branch: `codex/ceremony-lifecycle-events-v16`
-Base: `origin/main` after merged PR #7
-Previous PR: `https://github.com/calcosmic/Aether/pull/5` (merged/closed; covered only the early branch state through `c1880184`)
-Merged PRs: `https://github.com/calcosmic/Aether/pull/6`, `https://github.com/calcosmic/Aether/pull/7`
-Open PR: `https://github.com/calcosmic/Aether/pull/8` (draft; not merged)
+Branch: `codex/ceremony-context-events-v16`
+Base: `origin/main` after merged PR #9
+Previous PRs: `https://github.com/calcosmic/Aether/pull/5` through `https://github.com/calcosmic/Aether/pull/9` are merged
+Open PR: `https://github.com/calcosmic/Aether/pull/10` (clean/mergeable)
 
 ## Purpose
 
@@ -34,7 +33,7 @@ There are two separate progress tracks in this checkout:
    lifecycle state only. Do not manually edit it to match code progress.
 2. **Branch implementation progress**: git commits plus this tracked handoff are
    the source of truth for what has actually been implemented on
-   `codex/ceremony-lifecycle-events-v16`.
+   `codex/ceremony-context-events-v16`.
 
 This mismatch is expected for this branch because implementation slices were
 committed directly while the persisted colony lifecycle was not advanced through
@@ -49,20 +48,18 @@ committed directly while the persisted colony lifecycle was not advanced through
 | Phase 3: rolling activity display | Implemented foundation | `.aether/ts/narrator.ts`, multi-wave activity tests, `dist/narrator.js` | TTY live redraw/debounce deferred until real terminal contract is clear |
 | Phase 4: build subagent bridge | Implemented for wrappers | `build --plan-only`, `build-finalize`, manifest `execution_plan`, Claude/OpenCode build wrappers, wrapper contract tests | Live platform smoke and any future specialist prompt polish |
 | Phase 5: continue and plan orchestration | Implemented for wrappers | `continue --plan-only`, `continue-finalize`, `plan --plan-only`, `plan-finalize`, wrapper contract tests | Live platform smoke; stall/confidence ceremony polish |
-| Phase 6: full lifecycle ceremony and skills | Partially implemented | Build ceremony emits from Go; TS renders generic lifecycle stages and context notices; Go emits pheromone/chamber plus plan/colonize/continue wave events and skill activation notices | Emit remaining QUEEN/Hive/midden/graveyard context from real state |
+| Phase 6: full lifecycle ceremony and skills | Implemented for Go-owned transitions | Build ceremony emits from Go; TS renders generic lifecycle stages and context notices; Go emits pheromone/chamber, plan/colonize/continue wave events, skill activation, entomb, midden, QUEEN, and Hive notices | None known beyond live platform smoke and release polish |
 | Phase 7: parity verification and release | Not done | Release/rollback notes exist | Cross-platform smoke, install/update release checks, PR review, release hardening |
 
-Safe continuation point: PR #6 and PR #7 are merged. PR #8 is still open as a
-draft for `codex/ceremony-lifecycle-events-v16`; it is not on `main` yet.
-The old `codex/ceremony-narrator-foundation-v16` branch still appears on
-GitHub because PR #7 was merged without deleting its source branch. Go-side
-wrapper smoke passed for `build 1 --plan-only`; true Claude/OpenCode Task-tool
-smoke remains pending because Codex cannot execute those platform Task-tool
-wrappers directly. The current working-tree slice continues Phase 6 Go-backed
-lifecycle ceremony emission for plan, colonize, continue wave events, and
-skill activation notices.
+Safe continuation point: PR #5 through PR #9 are merged. PR #10 is open,
+clean, and mergeable for `codex/ceremony-context-events-v16`. The old
+`codex/ceremony-narrator-foundation-v16` branch still appears on GitHub
+because PR #7 was merged without deleting its source branch. Go-side wrapper
+smoke passed for `build 1 --plan-only`; true Claude/OpenCode Task-tool smoke
+remains pending because Codex cannot execute those platform Task-tool wrappers
+directly.
 
-## Already Shipped On This Branch
+## Already Shipped Across Merged Ceremony Branches
 
 These commits are pushed:
 
@@ -1087,6 +1084,53 @@ Verification run:
 - `go test ./... -count=1 -timeout 300s`
 - `go vet ./...`
 
+## Working Tree Slice: Phase 6 Lifecycle Context Events
+
+Date: 2026-04-24
+
+This slice covers the remaining Go-owned lifecycle context transitions that are
+not build waves: graveyard/chamber archival, midden records, QUEEN promotion,
+and Hive wisdom writes.
+
+Changed files:
+
+- `pkg/events/ceremony.go`
+- `cmd/entomb_cmd.go`
+- `cmd/midden_cmds.go`
+- `cmd/queen.go`
+- `cmd/hive.go`
+- `cmd/ceremony_emitter_test.go`
+- `.aether/ts/test/narrator.test.ts`
+
+Implemented behavior:
+
+- New context event topics:
+  `ceremony.chamber.entomb`, `ceremony.midden.record`,
+  `ceremony.queen.promote`, `ceremony.hive.store`, and
+  `ceremony.hive.promote`.
+- `aether entomb` emits `ceremony.chamber.entomb` after chamber archival,
+  active-state reset, runtime cleanup, and recovery doc write succeed.
+- `midden-write` emits `ceremony.midden.record` after the failure record is
+  persisted.
+- `queen-promote` and `queen-promote-instinct` emit
+  `ceremony.queen.promote` after QUEEN.md is updated.
+- `hive-store` emits `ceremony.hive.store`; `hive-promote` emits
+  `ceremony.hive.promote`, including both new entries and reinforced/boosted
+  existing entries.
+- The TypeScript narrator already handles these as generic Context notices; the
+  TS narrator test fixture now covers archive and wisdom context events.
+
+Verification run:
+
+- `go test ./cmd -run 'Test(EntombEmitsChamberEntombCeremonyEvent|MiddenWriteEmitsCeremonyEvent|QueenPromoteEmitsCeremonyEvent|HiveStoreAndPromoteEmitCeremonyEvents|.*Ceremony|Ceremony)' -count=1`
+- `npm run typecheck --prefix .aether/ts`
+- `npm ci --prefix .aether/ts`
+- `npm test --prefix .aether/ts`
+- `go test ./cmd -count=1`
+- `go test ./... -count=1 -timeout 300s`
+- `go vet ./...`
+- `git diff --check`
+
 ## Release And Rollback
 
 Rollback controls:
@@ -1107,28 +1151,25 @@ Before release:
 
 ## Current Next Step
 
-Next, commit and push the Phase 6 skill activation event slice to PR #8, then
-continue with remaining graveyard/entomb and QUEEN/Hive/midden context events
-where Go-owned state transitions exist. Platform Task-tool smoke is still
-required when Claude or OpenCode is available. The preconditions now satisfied
-are:
+Next, review/merge PR #10, then run platform Task-tool smoke when Claude or
+OpenCode is available. The preconditions now satisfied are:
 
-1. hub fallback smoke passed in a temporary HOME;
-2. TTY live redraw is consciously deferred;
-3. multi-wave TS fixture passes;
-4. build, continue, and plan wrappers now have plan-only/finalizer bridges;
-5. focused Go, full Go, TS, vet, and whitespace gates pass;
-6. PR #8 is open as a draft and not merged;
-7. the branch has merged the PR #5 squash commit from `main` with an
-   ancestry-only merge because its tree already matched branch commit
-   `c1880184`;
-8. PR #6 and PR #7 are merged;
-9. Go-side wrapper smoke passed for
+1. PR #5 through PR #9 are merged;
+2. PR #10 is open, clean, and mergeable;
+3. hub fallback smoke passed in a temporary HOME;
+4. TTY live redraw is consciously deferred;
+5. multi-wave TS fixture passes;
+6. build, continue, and plan wrappers now have plan-only/finalizer bridges;
+7. focused Go, full Go, TS, vet, and whitespace gates pass;
+8. Go-side wrapper smoke passed for
    `AETHER_OUTPUT_MODE=json go run ./cmd/aether build 1 --plan-only`, producing
    standard-depth builder wave 11, Probe wave 12, and Watcher wave 13;
-10. Phase 6 pheromone/chamber event hooks are implemented and verified;
-11. Phase 6 plan/colonize/continue wave event hooks are implemented in the
+9. Phase 6 pheromone/chamber event hooks are implemented and verified;
+10. Phase 6 plan/colonize/continue wave event hooks are implemented in the
     working tree with focused, full cmd, full repo, vet, and whitespace checks
     passing;
-12. Phase 6 skill activation event hooks are implemented in the working tree
-    with focused, full cmd, full repo, vet, and whitespace checks passing.
+11. Phase 6 skill activation event hooks are merged with focused, full cmd,
+    full repo, vet, and whitespace checks passing;
+12. Phase 6 lifecycle context events for entomb, midden, QUEEN, and Hive are
+    implemented in the working tree with focused Go, TS narrator, full cmd,
+    full repo, vet, and whitespace gates passing.

--- a/.aether/ts/test/narrator.test.ts
+++ b/.aether/ts/test/narrator.test.ts
@@ -408,3 +408,60 @@ test("keeps lifecycle context notices for skills pheromones and chambers", () =>
   assert.match(rendered, /ceremony\.chamber\.seal sealed Lifecycle ceremony checkpoint/);
   assert.match(rendered, /Workers: none active yet/);
 });
+
+test("keeps lifecycle context notices for archive and wisdom events", () => {
+  const frame = createCeremonyFrame();
+  for (const raw of [
+    {
+      topic: "ceremony.chamber.entomb",
+      payload: {
+        status: "entombed",
+        task_id: "20260424-meta-finish-v16",
+        message: "Finish v1.6 ceremony events"
+      }
+    },
+    {
+      topic: "ceremony.midden.record",
+      payload: {
+        status: "recorded",
+        task: "testing",
+        message: "Smoke failure recorded"
+      }
+    },
+    {
+      topic: "ceremony.queen.promote",
+      payload: {
+        status: "promoted",
+        task: "Patterns",
+        message: "Prefer narrow event hooks"
+      }
+    },
+    {
+      topic: "ceremony.hive.store",
+      payload: {
+        status: "stored",
+        task: "docs",
+        message: "Keep handoff current"
+      }
+    },
+    {
+      topic: "ceremony.hive.promote",
+      payload: {
+        status: "promoted",
+        task: "general",
+        message: "Prefer focused fixes"
+      }
+    }
+  ]) {
+    const event = parseEvent(JSON.stringify(raw));
+    assert.ok(event);
+    applyEventToFrame(frame, event);
+  }
+
+  const rendered = renderActivityFrame(frame);
+  assert.match(rendered, /ceremony\.chamber\.entomb entombed Finish v1\.6 ceremony events/);
+  assert.match(rendered, /ceremony\.midden\.record recorded Smoke failure recorded/);
+  assert.match(rendered, /ceremony\.queen\.promote promoted Prefer narrow event hooks/);
+  assert.match(rendered, /ceremony\.hive\.store stored Keep handoff current/);
+  assert.match(rendered, /ceremony\.hive\.promote promoted Prefer focused fixes/);
+});

--- a/cmd/ceremony_emitter_test.go
+++ b/cmd/ceremony_emitter_test.go
@@ -380,6 +380,139 @@ func TestResolveSkillSectionEmitsSkillActivationCeremony(t *testing.T) {
 	}
 }
 
+func TestEntombEmitsChamberEntombCeremonyEvent(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+	dataDir := setupBuildFlowTest(t)
+	aetherRoot := os.Getenv("AETHER_ROOT")
+	var buf bytes.Buffer
+	stdout = &buf
+
+	goal := "Entomb ceremony events"
+	createTestColonyState(t, dataDir, colony.ColonyState{
+		Version:      "3.0",
+		Goal:         &goal,
+		State:        colony.StateCOMPLETED,
+		CurrentPhase: 1,
+		Milestone:    "Crowned Anthill",
+		Plan: colony.Plan{Phases: []colony.Phase{{
+			ID:     1,
+			Name:   "Archive",
+			Status: colony.PhaseCompleted,
+		}}},
+	})
+
+	for path, content := range map[string]string{
+		filepath.Join(aetherRoot, ".aether", "CROWNED-ANTHILL.md"): "# Crowned Anthill\n",
+		filepath.Join(aetherRoot, ".aether", "HANDOFF.md"):         "# Old handoff\n",
+		filepath.Join(aetherRoot, ".aether", "CONTEXT.md"):         "# Old context\n",
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatalf("create parent for %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("write fixture %s: %v", path, err)
+		}
+	}
+
+	rootCmd.SetArgs([]string{"entomb"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("entomb returned error: %v", err)
+	}
+
+	persisted := readPersistedCeremonyEvents(t)
+	assertCeremonyTopics(t, persisted, events.CeremonyTopicChamberEntomb)
+	var payload events.CeremonyPayload
+	if err := json.Unmarshal(persisted[len(persisted)-1].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Status != "entombed" || payload.Message != goal || payload.Completed != 1 || payload.Total != 1 {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if payload.TaskID == "" || payload.Task == "" {
+		t.Fatalf("payload missing chamber context: %+v", payload)
+	}
+}
+
+func TestMiddenWriteEmitsCeremonyEvent(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+	s, _ := newTestStore(t)
+	store = s
+	var buf bytes.Buffer
+	stdout = &buf
+
+	rootCmd.SetArgs([]string{"midden-write", "--category", "testing", "--message", "test failure", "--source", "unit"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("midden-write returned error: %v", err)
+	}
+
+	persisted := readPersistedCeremonyEvents(t)
+	assertCeremonyTopics(t, persisted, events.CeremonyTopicMiddenRecord)
+	var payload events.CeremonyPayload
+	if err := json.Unmarshal(persisted[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Status != "recorded" || payload.Task != "testing" || payload.Message != "test failure" || payload.TaskID == "" {
+		t.Fatalf("payload = %+v", payload)
+	}
+}
+
+func TestQueenPromoteEmitsCeremonyEvent(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+	s, tmpDir := newTestStore(t)
+	store = s
+	var buf bytes.Buffer
+	stdout = &buf
+
+	hubDir := filepath.Join(tmpDir, "hub")
+	origHub := os.Getenv("AETHER_HUB_DIR")
+	os.Setenv("AETHER_HUB_DIR", hubDir)
+	t.Cleanup(func() { os.Setenv("AETHER_HUB_DIR", origHub) })
+
+	rootCmd.SetArgs([]string{"queen-promote", "pattern", "Prefer focused ceremony events"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("queen-promote returned error: %v", err)
+	}
+
+	persisted := readPersistedCeremonyEvents(t)
+	assertCeremonyTopics(t, persisted, events.CeremonyTopicQueenPromote)
+	var payload events.CeremonyPayload
+	if err := json.Unmarshal(persisted[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Status != "promoted" || payload.Task != "Patterns" || payload.Message != "Prefer focused ceremony events" {
+		t.Fatalf("payload = %+v", payload)
+	}
+}
+
+func TestHiveStoreAndPromoteEmitCeremonyEvents(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+	s, tmpDir := newTestStore(t)
+	store = s
+	var buf bytes.Buffer
+	stdout = &buf
+
+	hubDir := filepath.Join(tmpDir, "hub")
+	origHub := os.Getenv("AETHER_HUB_DIR")
+	os.Setenv("AETHER_HUB_DIR", hubDir)
+	t.Cleanup(func() { os.Setenv("AETHER_HUB_DIR", origHub) })
+
+	rootCmd.SetArgs([]string{"hive-store", "Keep docs aligned", "docs", "aether"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("hive-store returned error: %v", err)
+	}
+	rootCmd.SetArgs([]string{"hive-promote", "--text", "Prefer focused fixes", "--source-repo", "aether", "--confidence", "0.9"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("hive-promote returned error: %v", err)
+	}
+
+	persisted := readPersistedCeremonyEvents(t)
+	assertCeremonyTopics(t, persisted, events.CeremonyTopicHiveStore, events.CeremonyTopicHivePromote)
+}
+
 func TestActiveBuildCeremonyScopeRestoresPreviousEmitter(t *testing.T) {
 	saveGlobals(t)
 	outer := &buildCeremonyEmitter{phaseID: 1, phaseName: "outer"}

--- a/cmd/entomb_cmd.go
+++ b/cmd/entomb_cmd.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/calcosmic/Aether/pkg/colony"
+	"github.com/calcosmic/Aether/pkg/events"
 	"github.com/spf13/cobra"
 )
 
@@ -98,6 +99,16 @@ var entombCmd = &cobra.Command{
 			outputError(2, fmt.Sprintf("failed to write entomb recovery docs: %v", err), nil)
 			return nil
 		}
+
+		emitLifecycleCeremony(events.CeremonyTopicChamberEntomb, events.CeremonyPayload{
+			PhaseName: "Chamber Entombed",
+			TaskID:    chamberName,
+			Task:      chamberDir,
+			Status:    "entombed",
+			Message:   goal,
+			Completed: completedPhaseCount(state),
+			Total:     len(state.Plan.Phases),
+		}, "aether-entomb")
 
 		result := map[string]interface{}{
 			"entombed":         true,

--- a/cmd/hive.go
+++ b/cmd/hive.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/calcosmic/Aether/pkg/events"
 	"github.com/spf13/cobra"
 )
 
@@ -105,6 +106,12 @@ var hiveStoreCmd = &cobra.Command{
 					outputError(2, fmt.Sprintf("failed to save: %v", err), nil)
 					return nil
 				}
+				emitLifecycleCeremony(events.CeremonyTopicHiveStore, events.CeremonyPayload{
+					TaskID:  e.ID,
+					Task:    domain,
+					Status:  "reinforced",
+					Message: text,
+				}, "aether-hive")
 				outputOK(map[string]interface{}{"stored": true, "reinforced": true, "id": e.ID})
 				return nil
 			}
@@ -139,6 +146,13 @@ var hiveStoreCmd = &cobra.Command{
 			outputError(2, fmt.Sprintf("failed to save: %v", err), nil)
 			return nil
 		}
+
+		emitLifecycleCeremony(events.CeremonyTopicHiveStore, events.CeremonyPayload{
+			TaskID:  entry.ID,
+			Task:    domain,
+			Status:  "stored",
+			Message: text,
+		}, "aether-hive")
 
 		outputOK(map[string]interface{}{"stored": true, "reinforced": false, "id": entry.ID, "total": len(wf.Entries)})
 		return nil
@@ -284,6 +298,12 @@ var hivePromoteCmd = &cobra.Command{
 					outputError(2, fmt.Sprintf("failed to save: %v", err), nil)
 					return nil
 				}
+				emitLifecycleCeremony(events.CeremonyTopicHivePromote, events.CeremonyPayload{
+					TaskID:  e.ID,
+					Task:    domain,
+					Status:  "boosted",
+					Message: abstracted,
+				}, "aether-hive")
 				outputOK(map[string]interface{}{"promoted": true, "boosted": true, "id": e.ID, "confidence": wf.Entries[i].Confidence})
 				return nil
 			}
@@ -315,6 +335,13 @@ var hivePromoteCmd = &cobra.Command{
 			outputError(2, fmt.Sprintf("failed to save: %v", err), nil)
 			return nil
 		}
+
+		emitLifecycleCeremony(events.CeremonyTopicHivePromote, events.CeremonyPayload{
+			TaskID:  entry.ID,
+			Task:    domain,
+			Status:  "promoted",
+			Message: abstracted,
+		}, "aether-hive")
 
 		outputOK(map[string]interface{}{"promoted": true, "boosted": false, "id": entry.ID, "confidence": confidence})
 		return nil

--- a/cmd/midden_cmds.go
+++ b/cmd/midden_cmds.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/calcosmic/Aether/pkg/colony"
+	"github.com/calcosmic/Aether/pkg/events"
 	"github.com/spf13/cobra"
 )
 
@@ -463,6 +464,13 @@ var middenWriteCmd = &cobra.Command{
 			outputError(2, fmt.Sprintf("failed to save midden: %v", err), nil)
 			return nil
 		}
+
+		emitLifecycleCeremony(events.CeremonyTopicMiddenRecord, events.CeremonyPayload{
+			TaskID:  entryID,
+			Task:    category,
+			Status:  "recorded",
+			Message: message,
+		}, "aether-midden")
 
 		outputOK(map[string]interface{}{
 			"success":      true,

--- a/cmd/queen.go
+++ b/cmd/queen.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/calcosmic/Aether/pkg/events"
 	"github.com/calcosmic/Aether/pkg/storage"
 	"github.com/spf13/cobra"
 )
@@ -125,6 +126,12 @@ var queenPromoteCmd = &cobra.Command{
 			outputError(2, fmt.Sprintf("failed to write QUEEN.md: %v", err), nil)
 			return nil
 		}
+
+		emitLifecycleCeremony(events.CeremonyTopicQueenPromote, events.CeremonyPayload{
+			Task:    section,
+			Status:  "promoted",
+			Message: sanitizeQueenInline(content),
+		}, "aether-queen")
 
 		outputOK(map[string]interface{}{"promoted": true, "section": section})
 		return nil
@@ -265,6 +272,13 @@ var queenPromoteInstinctCmd = &cobra.Command{
 			outputError(2, fmt.Sprintf("failed to write QUEEN.md: %v", err), nil)
 			return nil
 		}
+
+		emitLifecycleCeremony(events.CeremonyTopicQueenPromote, events.CeremonyPayload{
+			TaskID:  instinctID,
+			Task:    "Wisdom",
+			Status:  "promoted",
+			Message: sanitizeQueenInline(action),
+		}, "aether-queen")
 
 		outputOK(map[string]interface{}{"promoted": true, "instinct_id": instinctID})
 		return nil

--- a/pkg/events/ceremony.go
+++ b/pkg/events/ceremony.go
@@ -20,6 +20,11 @@ const (
 	CeremonyTopicPheromoneEmit     = "ceremony.pheromone.emit"
 	CeremonyTopicSkillActivate     = "ceremony.skill.activate"
 	CeremonyTopicChamberSeal       = "ceremony.chamber.seal"
+	CeremonyTopicChamberEntomb     = "ceremony.chamber.entomb"
+	CeremonyTopicMiddenRecord      = "ceremony.midden.record"
+	CeremonyTopicQueenPromote      = "ceremony.queen.promote"
+	CeremonyTopicHiveStore         = "ceremony.hive.store"
+	CeremonyTopicHivePromote       = "ceremony.hive.promote"
 )
 
 // CeremonyPayload is the shared event shape consumed by the bundled narrator.
@@ -76,5 +81,10 @@ func CeremonyTopics() []string {
 		CeremonyTopicPheromoneEmit,
 		CeremonyTopicSkillActivate,
 		CeremonyTopicChamberSeal,
+		CeremonyTopicChamberEntomb,
+		CeremonyTopicMiddenRecord,
+		CeremonyTopicQueenPromote,
+		CeremonyTopicHiveStore,
+		CeremonyTopicHivePromote,
 	}
 }


### PR DESCRIPTION
## Summary
- add lifecycle context event topics for chamber entomb, midden records, QUEEN promotion, and Hive store/promote
- emit those events from Go-owned state transitions after persistence succeeds
- extend Go and TypeScript narrator tests plus update the v1.6 handoff/context notes

## Verification
- `go test ./cmd -run 'Test(EntombEmitsChamberEntombCeremonyEvent|MiddenWriteEmitsCeremonyEvent|QueenPromoteEmitsCeremonyEvent|HiveStoreAndPromoteEmitCeremonyEvents|.*Ceremony|Ceremony)' -count=1`
- `npm run typecheck --prefix .aether/ts`
- `npm ci --prefix .aether/ts`
- `npm test --prefix .aether/ts`
- `go test ./cmd -count=1`
- `go test ./... -count=1 -timeout 300s`
- `go vet ./...`
- `git diff --check`