### PR TITLE
fix: harden publish update artifact hygiene

### DIFF
--- a/.aether/CONTEXT.md
+++ b/.aether/CONTEXT.md
@@ -8,7 +8,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Last Updated** | 2026-04-24T12:22:11Z |
+| **Last Updated** | 2026-04-24T13:24:10Z |
 | **Current Phase** | 1 |
 | **Phase Name** | Assumptions and gap audit |
 | **Phase Status** | ready |
@@ -27,6 +27,8 @@ Restore the agent spawning bridge — bring back full ceremony, real agent dispa
 ## What's In Progress
 
 Blended v1.6 ceremony revival plan persisted: Go owns state/events, TypeScript narrator owns visuals, wrappers own real Task-tool spawning. Current persisted colony phase: Assumptions and gap audit.
+
+Phase 7 release hygiene is in progress on `codex/phase7-release-hygiene`. PR #5 through PR #11 are merged into `origin/main`; the active branch contains only publish/update artifact hygiene plus tests and tracked handoff updates. Stable and dev were republished separately from source at `1.0.22` with `aether publish --channel stable --binary-dest "$HOME/.local/bin"` and `aether publish --channel dev --binary-dest "$HOME/.local/bin"`.
 
 Detailed handoff note: `.aether/dreams/2026-04-24-ceremony-revival-v1.6-handoff.md`.
 
@@ -70,7 +72,7 @@ TypeScript lifecycle-context rendering slice is in the working tree: `.aether/ts
 
 Broad checkpoint verification passed on 2026-04-24T11:27:54Z: TS install/typecheck/test/build, `gofmt`, `git diff --check`, `go test ./cmd -count=1`, `go test ./... -count=1 -timeout 300s`, and `go vet ./...`.
 
-GitHub PR status: PR #5, PR #6, PR #7, PR #8, and PR #9 are merged. PR #10 is open, clean, and mergeable for `codex/ceremony-context-events-v16`. The old `codex/ceremony-narrator-foundation-v16` branch still appears on GitHub because PR #7 was merged but the source branch was not deleted.
+GitHub PR status: PR #5 through PR #11 are merged. Next GitHub step is to open/review/merge the release-hygiene PR from `codex/phase7-release-hygiene` before any public tag/release.
 
 Go-side wrapper smoke passed with `AETHER_OUTPUT_MODE=json go run ./cmd/aether build 1 --plan-only`: the standard-depth manifest emitted builder execution wave 11, Probe wave 12, and Watcher wave 13. True Claude/OpenCode Task-tool smoke remains pending because Codex cannot execute those platform wrapper tools directly.
 
@@ -82,7 +84,7 @@ Phase 6 skill activation ceremony slice is complete in the working tree: `resolv
 
 Phase 6 lifecycle context event slice is complete in the working tree on `codex/ceremony-context-events-v16`: entomb, midden-write, queen-promote, hive-store, and hive-promote now emit Go-owned ceremony context events (`ceremony.chamber.entomb`, `ceremony.midden.record`, `ceremony.queen.promote`, `ceremony.hive.store`, `ceremony.hive.promote`). The TypeScript narrator renders these as generic Context notices. Focused Go ceremony tests, `npm run typecheck --prefix .aether/ts`, `npm test --prefix .aether/ts`, `go test ./cmd -count=1`, `go test ./... -count=1 -timeout 300s`, `go vet ./...`, and `git diff --check` passed.
 
-PR #10 URL: `https://github.com/calcosmic/Aether/pull/10`
+Phase 7 release hygiene verification completed on the working branch: focused sync tests, `go test ./...`, race tests, vet, build, TS ci/typecheck/test/build, dist drift check, npm bootstrap tests, npm pack dry run, stable/dev integrity, downstream stable/dev update smokes, JSON/visual narrator smokes, and missing-Node fallback smoke all passed. Hubs now have `.aether/ts/dist/narrator.js` and no stale `.DS_Store`, local-only hub dirs, or `node_modules` under `system/`.
 
 ---
 
@@ -160,9 +162,10 @@ PR #10 URL: `https://github.com/calcosmic/Aether/pull/10`
 
 ## Next Steps
 
-1. Review/merge PR #10
+1. Open/review/merge the release-hygiene PR from `codex/phase7-release-hygiene`
 2. Run true Claude/OpenCode build wrapper smoke with platform Task-tool agents when available
 3. Keep Go as state/event source of truth; wrappers own Task-tool spawning
+4. Tag/release only after the release-hygiene PR is merged and final release checks are repeated from main
 
 ---
 
@@ -173,4 +176,5 @@ PR #10 URL: `https://github.com/calcosmic/Aether/pull/10`
 3. Read `.aether/HANDOFF.md` if a richer session summary was persisted
 
 ### Active Todos
+- Open/merge release-hygiene PR
 - Live smoke the build wrapper path with real platform agents

--- a/.aether/docs/ceremony-revival-v1.6-handoff.md
+++ b/.aether/docs/ceremony-revival-v1.6-handoff.md
@@ -1,11 +1,11 @@
 # Ceremony Revival v1.6 Handoff
 
-Last updated: 2026-04-24T12:38:25Z
+Last updated: 2026-04-24T13:24:10Z
 
-Branch: `codex/ceremony-context-events-v16`
-Base: `origin/main` after merged PR #9
-Previous PRs: `https://github.com/calcosmic/Aether/pull/5` through `https://github.com/calcosmic/Aether/pull/9` are merged
-Open PR: `https://github.com/calcosmic/Aether/pull/10` (clean/mergeable)
+Branch: `codex/phase7-release-hygiene`
+Base: `origin/main` after merged PR #11
+Previous PRs: `https://github.com/calcosmic/Aether/pull/5` through `https://github.com/calcosmic/Aether/pull/11` are merged
+Open PR: release-hygiene PR pending from `codex/phase7-release-hygiene`
 
 ## Purpose
 
@@ -49,15 +49,13 @@ committed directly while the persisted colony lifecycle was not advanced through
 | Phase 4: build subagent bridge | Implemented for wrappers | `build --plan-only`, `build-finalize`, manifest `execution_plan`, Claude/OpenCode build wrappers, wrapper contract tests | Live platform smoke and any future specialist prompt polish |
 | Phase 5: continue and plan orchestration | Implemented for wrappers | `continue --plan-only`, `continue-finalize`, `plan --plan-only`, `plan-finalize`, wrapper contract tests | Live platform smoke; stall/confidence ceremony polish |
 | Phase 6: full lifecycle ceremony and skills | Implemented for Go-owned transitions | Build ceremony emits from Go; TS renders generic lifecycle stages and context notices; Go emits pheromone/chamber, plan/colonize/continue wave events, skill activation, entomb, midden, QUEEN, and Hive notices | None known beyond live platform smoke and release polish |
-| Phase 7: parity verification and release | Not done | Release/rollback notes exist | Cross-platform smoke, install/update release checks, PR review, release hardening |
+| Phase 7: parity verification and release | In release hygiene | Stable/dev publish and downstream update smokes passed on `codex/phase7-release-hygiene` | Open/merge release-hygiene PR, then tag/release only after final review |
 
-Safe continuation point: PR #5 through PR #9 are merged. PR #10 is open,
-clean, and mergeable for `codex/ceremony-context-events-v16`. The old
-`codex/ceremony-narrator-foundation-v16` branch still appears on GitHub
-because PR #7 was merged without deleting its source branch. Go-side wrapper
-smoke passed for `build 1 --plan-only`; true Claude/OpenCode Task-tool smoke
-remains pending because Codex cannot execute those platform Task-tool wrappers
-directly.
+Safe continuation point: PR #5 through PR #11 are merged into `origin/main`.
+The current release-hygiene branch contains only publish/update artifact hygiene
+and regression tests. Go-side wrapper smoke passed for `build 1 --plan-only`;
+true Claude/OpenCode Task-tool smoke remains pending because Codex cannot
+execute those platform Task-tool wrappers directly.
 
 ## Already Shipped Across Merged Ceremony Branches
 
@@ -1131,6 +1129,75 @@ Verification run:
 - `go vet ./...`
 - `git diff --check`
 
+## Working Tree Slice: Phase 7 Release Hygiene
+
+Date: 2026-04-24
+
+This slice covers the release/publish hygiene found during final verification:
+stable publish had not synced `.aether/ts` into `~/.aether/system`, and older
+hub publishes could leave stale local-only directories or ignored files in the
+shared hub. The fix keeps the stable and dev channels separate while making
+publish/update clean up generated artifacts predictably.
+
+Changed files:
+
+- `cmd/install_cmd.go`
+- `cmd/install_cmd_test.go`
+- `cmd/update_cmd.go`
+- `cmd/update_cmd_test.go`
+- `.aether/docs/ceremony-revival-v1.6-handoff.md`
+
+Implemented behavior:
+
+- Install/publish sync ignores `.DS_Store` and `node_modules` as sync artifacts.
+- Hub publishing removes stale excluded local-only directories from
+  `~/.aether/system` and `~/.aether-dev/system`, including `archive/`,
+  `backups/`, `chambers/`, nested `.aether/`, and nested `node_modules/`.
+- `aether update --force` still removes stale managed files, but preserves
+  local-only state directories such as `archive/`, `backups/`, `chambers/`,
+  `data/`, `dreams/`, `oracle/`, `checkpoints/`, `locks/`, and `temp/`.
+- Stable and dev were republished separately with:
+  - `go run ./cmd/aether publish --channel stable --binary-dest "$HOME/.local/bin"`
+  - `go run ./cmd/aether publish --channel dev --binary-dest "$HOME/.local/bin"`
+- Stable `aether` and dev `aether-dev` both report version `1.0.22`; both
+  channel-specific integrity checks pass.
+
+Verification run:
+
+- `go test ./cmd -run 'TestSyncDirSkipsDSStoreAndRemovesStaleDSStore|TestSyncDirToHubSkipsIgnoredAndExcludedArtifacts|TestRunUpdateSyncCopiesNarratorPackageButSkipsNodeModules|TestUpdateSyncPreservesProtectedDirs|TestUpdateSyncForceDoesNotRemoveProtectedStale' -count=1`
+- `go test ./... -count=1`
+- `go test ./... -race -count=1 -timeout 600s`
+- `go vet ./...`
+- `go build ./cmd/aether`
+- `git diff --check`
+- `npm --prefix .aether/ts ci`
+- `npm --prefix .aether/ts run typecheck`
+- `npm --prefix .aether/ts test`
+- `npm --prefix .aether/ts run build`
+- `git diff --exit-code -- .aether/ts/dist/narrator.js`
+- `npm --prefix npm test`
+- `npm pack --dry-run` from `npm/`
+- `AETHER_OUTPUT_MODE=json aether integrity --source --json`
+- `AETHER_OUTPUT_MODE=json aether-dev integrity --source --channel dev --json`
+- Downstream update smoke for both `aether` and `aether-dev`: narrator runtime
+  synced, stale `.DS_Store` and `node_modules` removed, local `archive/` and
+  `chambers/` preserved, and `binary_refresh_mode` stayed `unchanged`.
+- Runtime narrator smoke: JSON mode stayed parseable and ceremony-free; visual
+  mode emitted the ceremony frame; missing Node fallback produced output without
+  crashing.
+
+Release rule reminder:
+
+- Use `aether publish --channel stable` to refresh `~/.aether` and rebuild the
+  stable `aether` binary from this source checkout.
+- Use `aether publish --channel dev` to refresh `~/.aether-dev` and rebuild the
+  dev `aether-dev` binary from this source checkout.
+- Use `aether update --force` or `aether-dev update --force` in downstream repos
+  to sync companion files. Update does not rebuild the binary unless
+  `--download-binary` is explicitly used for a published release.
+- Do not use `aether update` as proof that an unreleased local runtime change
+  reached the shared binary. Source-runtime changes require publish.
+
 ## Release And Rollback
 
 Rollback controls:
@@ -1142,8 +1209,12 @@ Rollback controls:
 
 Before release:
 
-- Verify `aether install --package-dir "$PWD"` publishes `.aether/ts` to hub.
-- Verify `aether update --force` syncs `.aether/ts` into a fixture repo.
+- Verify `aether publish --channel stable --binary-dest "$HOME/.local/bin"`
+  publishes `.aether/ts` to `~/.aether/system` and rebuilds stable `aether`.
+- Verify `aether publish --channel dev --binary-dest "$HOME/.local/bin"`
+  publishes `.aether/ts` to `~/.aether-dev/system` and rebuilds `aether-dev`.
+- Verify downstream `aether update --force` and `aether-dev update --force` sync
+  `.aether/ts` into fixture repos while preserving local-only state dirs.
 - Verify missing Node falls back cleanly.
 - Verify JSON mode is never polluted.
 - Verify Claude Code, OpenCode, and Codex docs correctly describe their
@@ -1151,11 +1222,13 @@ Before release:
 
 ## Current Next Step
 
-Next, review/merge PR #10, then run platform Task-tool smoke when Claude or
+Next, open and review the release-hygiene PR from
+`codex/phase7-release-hygiene`, then merge it before tagging or publishing a
+public release. After that, run platform Task-tool smoke when Claude or
 OpenCode is available. The preconditions now satisfied are:
 
-1. PR #5 through PR #9 are merged;
-2. PR #10 is open, clean, and mergeable;
+1. PR #5 through PR #11 are merged;
+2. `codex/phase7-release-hygiene` is based on current `origin/main`;
 3. hub fallback smoke passed in a temporary HOME;
 4. TTY live redraw is consciously deferred;
 5. multi-wave TS fixture passes;
@@ -1171,5 +1244,10 @@ OpenCode is available. The preconditions now satisfied are:
 11. Phase 6 skill activation event hooks are merged with focused, full cmd,
     full repo, vet, and whitespace checks passing;
 12. Phase 6 lifecycle context events for entomb, midden, QUEEN, and Hive are
-    implemented in the working tree with focused Go, TS narrator, full cmd,
-    full repo, vet, and whitespace gates passing.
+    merged with focused Go, TS narrator, full cmd, full repo, vet, and
+    whitespace gates passing;
+13. stable and dev publishes were run separately from source and both channel
+    integrity checks pass at `1.0.22`;
+14. downstream stable/dev update smokes passed with narrator sync, ignored
+    artifact cleanup, local state preservation, and unchanged binary reporting;
+15. JSON, visual narrator, and missing-Node fallback smokes passed.

--- a/cmd/install_cmd.go
+++ b/cmd/install_cmd.go
@@ -329,11 +329,10 @@ func syncDir(src, dest string, opts syncOptions) syncResult {
 	if opts.include != nil {
 		srcFiles = filterSyncFiles(srcFiles, opts.include)
 	}
+	var ignored int
+	srcFiles, ignored = filterIgnoredSyncFiles(srcFiles)
+	result.skipped += ignored
 	for _, relPath := range srcFiles {
-		if syncPathHasComponent(relPath, "node_modules") {
-			result.skipped++
-			continue
-		}
 		if syncPathProtected(relPath, opts.protectedDirs, opts.protectedFiles) {
 			result.skipped++
 			continue
@@ -398,10 +397,16 @@ func syncDir(src, dest string, opts syncOptions) syncResult {
 		}
 
 		for _, relPath := range destFiles {
-			if syncPathHasComponent(relPath, "node_modules") {
+			if syncPathProtected(relPath, opts.protectedDirs, opts.protectedFiles) {
 				continue
 			}
-			if syncPathProtected(relPath, opts.protectedDirs, opts.protectedFiles) {
+			if syncPathIgnored(relPath) {
+				destPath := filepath.Join(dest, relPath)
+				if err := os.Remove(destPath); err == nil {
+					result.removed = append(result.removed, relPath)
+				} else if !os.IsNotExist(err) {
+					result.errors = append(result.errors, fmt.Sprintf("remove %s: %v", destPath, err))
+				}
 				continue
 			}
 			if opts.include != nil && !opts.include(relPath) {
@@ -421,6 +426,9 @@ func syncDir(src, dest string, opts syncOptions) syncResult {
 		if len(result.removed) > 0 {
 			cleanEmptyDirs(dest)
 		}
+		removed, errors := removeIgnoredDirsRecursive(dest, opts.protectedDirs, opts.include)
+		result.removed = append(result.removed, removed...)
+		result.errors = append(result.errors, errors...)
 	}
 
 	return result
@@ -553,6 +561,8 @@ var hubExcludeDirs = map[string]bool{
 	"temp":         true,
 	"archive":      true,
 	"chambers":     true,
+	"backups":      true,
+	".aether":      true,
 	"agents":       true, // agents/ is opencode-only, agents-claude/ is the packaging mirror
 	"examples":     true,
 	"node_modules": true,
@@ -701,11 +711,10 @@ func syncDirToHubWithExclusion(src, dest string, exclude map[string]bool, valida
 	if include != nil {
 		srcFiles = filterSyncFiles(srcFiles, include)
 	}
+	var ignored int
+	srcFiles, ignored = filterIgnoredSyncFiles(srcFiles)
+	result.skipped += ignored
 	for _, relPath := range srcFiles {
-		if syncPathHasComponent(relPath, "node_modules") {
-			result.skipped++
-			continue
-		}
 		srcPath := filepath.Join(src, relPath)
 		destPath := filepath.Join(dest, relPath)
 
@@ -750,8 +759,17 @@ func syncDirToHubWithExclusion(src, dest string, exclude map[string]bool, valida
 		srcSet[f] = struct{}{}
 	}
 	for _, relPath := range destFiles {
-		// Don't remove files in excluded dirs (they may have been added manually)
-		if pathHasExcludedComponent(relPath, exclude) || syncPathHasComponent(relPath, "node_modules") {
+		if syncPathIgnored(relPath) {
+			destPath := filepath.Join(dest, relPath)
+			if err := os.Remove(destPath); err == nil {
+				result.removed = append(result.removed, relPath)
+			} else if !os.IsNotExist(err) {
+				result.errors = append(result.errors, fmt.Sprintf("remove %s: %v", destPath, err))
+			}
+			continue
+		}
+		// Excluded hub dirs are removed as whole directories after stale-file cleanup.
+		if pathHasExcludedComponent(relPath, exclude) {
 			continue
 		}
 		if include != nil && !include(relPath) {
@@ -770,6 +788,9 @@ func syncDirToHubWithExclusion(src, dest string, exclude map[string]bool, valida
 	if len(result.removed) > 0 {
 		cleanEmptyDirs(dest)
 	}
+	removed, errors := removeExcludedDirsRecursive(dest, exclude)
+	result.removed = append(result.removed, removed...)
+	result.errors = append(result.errors, errors...)
 
 	return result
 }
@@ -798,6 +819,80 @@ func listFilesRecursiveWithExclusion(baseDir string, exclude map[string]bool) []
 		return nil
 	})
 	return files
+}
+
+func filterIgnoredSyncFiles(relPaths []string) ([]string, int) {
+	filtered := make([]string, 0, len(relPaths))
+	skipped := 0
+	for _, relPath := range relPaths {
+		if syncPathIgnored(relPath) {
+			skipped++
+			continue
+		}
+		filtered = append(filtered, relPath)
+	}
+	return filtered, skipped
+}
+
+func syncPathIgnored(relPath string) bool {
+	if filepath.Base(relPath) == ".DS_Store" {
+		return true
+	}
+	return syncPathHasComponent(relPath, "node_modules")
+}
+
+func removeIgnoredDirsRecursive(baseDir string, protectedDirs map[string]bool, include syncFilter) ([]string, []string) {
+	var removed []string
+	var errs []string
+	if include != nil {
+		return removed, errs
+	}
+	_ = filepath.WalkDir(baseDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || !d.IsDir() || path == baseDir {
+			return nil
+		}
+		rel, relErr := filepath.Rel(baseDir, path)
+		if relErr != nil {
+			return nil
+		}
+		if syncPathProtected(rel, protectedDirs, nil) {
+			return filepath.SkipDir
+		}
+		if filepath.Base(rel) != "node_modules" {
+			return nil
+		}
+		if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Sprintf("remove ignored %s: %v", path, err))
+			return filepath.SkipDir
+		}
+		removed = append(removed, rel)
+		return filepath.SkipDir
+	})
+	return removed, errs
+}
+
+func removeExcludedDirsRecursive(baseDir string, exclude map[string]bool) ([]string, []string) {
+	var removed []string
+	var errs []string
+	if len(exclude) == 0 {
+		return removed, errs
+	}
+	_ = filepath.WalkDir(baseDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || !d.IsDir() || path == baseDir {
+			return nil
+		}
+		rel, relErr := filepath.Rel(baseDir, path)
+		if relErr != nil || !pathHasExcludedComponent(rel, exclude) {
+			return nil
+		}
+		if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Sprintf("remove excluded %s: %v", path, err))
+			return filepath.SkipDir
+		}
+		removed = append(removed, rel)
+		return filepath.SkipDir
+	})
+	return removed, errs
 }
 
 func pathHasExcludedComponent(relPath string, exclude map[string]bool) bool {

--- a/cmd/install_cmd_test.go
+++ b/cmd/install_cmd_test.go
@@ -213,6 +213,126 @@ func TestSyncDirSkipsNestedNodeModules(t *testing.T) {
 	}
 }
 
+func TestSyncDirSkipsDSStoreAndRemovesStaleDSStore(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "ts"), 0755); err != nil {
+		t.Fatalf("failed to create source fixture: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dest, "ts"), 0755); err != nil {
+		t.Fatalf("failed to create dest fixture: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dest, "ts", "node_modules", "tsx"), 0755); err != nil {
+		t.Fatalf("failed to create stale dest node_modules fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "ts", "narrator.ts"), []byte("export {};\n"), 0644); err != nil {
+		t.Fatalf("failed to write narrator fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, ".DS_Store"), []byte("metadata"), 0644); err != nil {
+		t.Fatalf("failed to write source root metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "ts", ".DS_Store"), []byte("metadata"), 0644); err != nil {
+		t.Fatalf("failed to write source nested metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "ts", ".DS_Store"), []byte("stale"), 0644); err != nil {
+		t.Fatalf("failed to write stale dest metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "ts", "node_modules", "tsx", "index.js"), []byte("stale"), 0644); err != nil {
+		t.Fatalf("failed to write stale dest node_modules file: %v", err)
+	}
+
+	result := syncDir(src, dest, syncOptions{cleanup: true})
+	if len(result.errors) > 0 {
+		t.Fatalf("syncDir returned errors: %v", result.errors)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "ts", "narrator.ts")); err != nil {
+		t.Fatalf("expected narrator fixture to sync: %v", err)
+	}
+	for _, path := range []string{
+		filepath.Join(dest, ".DS_Store"),
+		filepath.Join(dest, "ts", ".DS_Store"),
+	} {
+		if _, err := os.Stat(path); err == nil {
+			t.Fatalf("syncDir should not leave .DS_Store at %s", path)
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dest, "ts", "node_modules")); err == nil {
+		t.Fatal("syncDir should remove stale node_modules directories during cleanup")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat stale node_modules: %v", err)
+	}
+}
+
+func TestSyncDirToHubSkipsIgnoredAndExcludedArtifacts(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "ts", "dist"), 0755); err != nil {
+		t.Fatalf("failed to create source fixture: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dest, "ts"), 0755); err != nil {
+		t.Fatalf("failed to create dest fixture: %v", err)
+	}
+	for _, dir := range []string{
+		filepath.Join(dest, "archive"),
+		filepath.Join(dest, "backups"),
+		filepath.Join(dest, "chambers"),
+		filepath.Join(dest, ".aether", "locks"),
+		filepath.Join(dest, "ts", "node_modules", "tsx"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("failed to create stale dest dir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(src, "ts", "dist", "narrator.js"), []byte("export {};\n"), 0644); err != nil {
+		t.Fatalf("failed to write narrator fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "ts", ".DS_Store"), []byte("metadata"), 0644); err != nil {
+		t.Fatalf("failed to write source metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "ts", ".DS_Store"), []byte("stale"), 0644); err != nil {
+		t.Fatalf("failed to write stale dest metadata: %v", err)
+	}
+	for _, path := range []string{
+		filepath.Join(dest, "archive", "old.md"),
+		filepath.Join(dest, "backups", "old.md"),
+		filepath.Join(dest, "chambers", "old.md"),
+		filepath.Join(dest, ".aether", "locks", "stale.lock"),
+		filepath.Join(dest, "ts", "node_modules", "tsx", "index.js"),
+	} {
+		if err := os.WriteFile(path, []byte("stale"), 0644); err != nil {
+			t.Fatalf("failed to write stale dest file %s: %v", path, err)
+		}
+	}
+
+	result := syncDirToHub(src, dest)
+	if len(result.errors) > 0 {
+		t.Fatalf("syncDirToHub returned errors: %v", result.errors)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "ts", "dist", "narrator.js")); err != nil {
+		t.Fatalf("expected narrator fixture to sync: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "ts", ".DS_Store")); err == nil {
+		t.Fatal("syncDirToHub should not leave .DS_Store in the hub")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat stale metadata: %v", err)
+	}
+	for _, path := range []string{
+		filepath.Join(dest, "archive"),
+		filepath.Join(dest, "backups"),
+		filepath.Join(dest, "chambers"),
+		filepath.Join(dest, ".aether"),
+		filepath.Join(dest, "ts", "node_modules"),
+	} {
+		if _, err := os.Stat(path); err == nil {
+			t.Fatalf("syncDirToHub should remove stale ignored or excluded artifact at %s", path)
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat stale artifact %s: %v", path, err)
+		}
+	}
+}
+
 // TestInstallCopiesClaudeCommands verifies that install copies .claude/commands/ant/
 // files to the target directory.
 func TestInstallCopiesClaudeCommands(t *testing.T) {

--- a/cmd/update_cmd.go
+++ b/cmd/update_cmd.go
@@ -263,8 +263,16 @@ func runUpdateSync(hubDir, repoDir string, force bool) updateSyncResult {
 
 	// Directories to never overwrite or remove (user data)
 	protectedDirs := map[string]bool{
-		"data":   true,
-		"dreams": true,
+		".aether":     true,
+		"archive":     true,
+		"backups":     true,
+		"chambers":    true,
+		"checkpoints": true,
+		"data":        true,
+		"dreams":      true,
+		"locks":       true,
+		"oracle":      true,
+		"temp":        true,
 	}
 	protectedFiles := map[string]bool{
 		"QUEEN.md":           true,

--- a/cmd/update_cmd_test.go
+++ b/cmd/update_cmd_test.go
@@ -72,6 +72,16 @@ func TestRunUpdateSyncCopiesNarratorPackageButSkipsNodeModules(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(hubTS, "node_modules", "tsx", "index.js"), []byte("module.exports = {};\n"), 0644); err != nil {
 		t.Fatalf("failed to write node_modules fixture: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(hubTS, ".DS_Store"), []byte("metadata"), 0644); err != nil {
+		t.Fatalf("failed to write .DS_Store fixture: %v", err)
+	}
+	localTS := filepath.Join(repoDir, ".aether", "ts")
+	if err := os.MkdirAll(filepath.Join(localTS, "node_modules", "tsx"), 0755); err != nil {
+		t.Fatalf("failed to create stale local node_modules fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localTS, "node_modules", "tsx", "index.js"), []byte("stale"), 0644); err != nil {
+		t.Fatalf("failed to write stale local node_modules fixture: %v", err)
+	}
 
 	result := runUpdateSync(hubDir, repoDir, true)
 	if len(result.errors) > 0 {
@@ -84,6 +94,9 @@ func TestRunUpdateSyncCopiesNarratorPackageButSkipsNodeModules(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(repoDir, ".aether", "ts", "node_modules")); err == nil {
 		t.Fatal("update sync should not copy .aether/ts/node_modules")
+	}
+	if _, err := os.Stat(filepath.Join(repoDir, ".aether", "ts", ".DS_Store")); err == nil {
+		t.Fatal("update sync should not copy .aether/ts/.DS_Store")
 	}
 }
 
@@ -563,8 +576,8 @@ func TestUpdateSyncNewFilesAreCopied(t *testing.T) {
 	}
 }
 
-// TestRunUpdateSyncPreservesProtectedDirs verifies that data/ and dreams/
-// directories are never overwritten.
+// TestRunUpdateSyncPreservesProtectedDirs verifies that local-only directories
+// are never overwritten.
 func TestUpdateSyncPreservesProtectedDirs(t *testing.T) {
 	saveGlobals(t)
 
@@ -572,39 +585,72 @@ func TestUpdateSyncPreservesProtectedDirs(t *testing.T) {
 	repoDir := t.TempDir()
 
 	hubSystem := filepath.Join(hubDir, "system")
-	hubData := filepath.Join(hubSystem, "data")
-	if err := os.MkdirAll(hubData, 0755); err != nil {
-		t.Fatalf("failed to create hub data dir: %v", err)
-	}
-
-	// Hub has a data file that differs from local
-	hubDataContent := []byte(`{"goal":"hub_goal","state":"HUB"}`)
-	if err := os.WriteFile(filepath.Join(hubData, "COLONY_STATE.json"), hubDataContent, 0644); err != nil {
-		t.Fatalf("failed to write hub data file: %v", err)
-	}
-
 	localAether := filepath.Join(repoDir, ".aether")
-	localData := filepath.Join(localAether, "data")
-	if err := os.MkdirAll(localData, 0755); err != nil {
-		t.Fatalf("failed to create local data dir: %v", err)
+	fixtures := map[string]struct {
+		name         string
+		hubContent   []byte
+		localContent []byte
+	}{
+		"archive": {
+			name:         "notes.md",
+			hubContent:   []byte("# Hub archive"),
+			localContent: []byte("# Local archive"),
+		},
+		"backups": {
+			name:         "backup.json",
+			hubContent:   []byte(`{"source":"hub"}`),
+			localContent: []byte(`{"source":"local"}`),
+		},
+		"chambers": {
+			name:         "chamber.md",
+			hubContent:   []byte("# Hub chamber"),
+			localContent: []byte("# Local chamber"),
+		},
+		"data": {
+			name:         "COLONY_STATE.json",
+			hubContent:   []byte(`{"goal":"hub_goal","state":"HUB"}`),
+			localContent: []byte(`{"goal":"user_goal","state":"ACTIVE"}`),
+		},
+		"dreams": {
+			name:         "dream.md",
+			hubContent:   []byte("# Hub dream"),
+			localContent: []byte("# Local dream"),
+		},
+		"oracle": {
+			name:         "research.md",
+			hubContent:   []byte("# Hub research"),
+			localContent: []byte("# Local research"),
+		},
 	}
-
-	localDataContent := []byte(`{"goal":"user_goal","state":"ACTIVE"}`)
-	if err := os.WriteFile(filepath.Join(localData, "COLONY_STATE.json"), localDataContent, 0644); err != nil {
-		t.Fatalf("failed to write local data file: %v", err)
+	for dir, fixture := range fixtures {
+		hubPath := filepath.Join(hubSystem, dir)
+		localPath := filepath.Join(localAether, dir)
+		if err := os.MkdirAll(hubPath, 0755); err != nil {
+			t.Fatalf("failed to create hub %s dir: %v", dir, err)
+		}
+		if err := os.MkdirAll(localPath, 0755); err != nil {
+			t.Fatalf("failed to create local %s dir: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(hubPath, fixture.name), fixture.hubContent, 0644); err != nil {
+			t.Fatalf("failed to write hub %s file: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(localPath, fixture.name), fixture.localContent, 0644); err != nil {
+			t.Fatalf("failed to write local %s file: %v", dir, err)
+		}
 	}
 
 	// Sync with force=true -- protected dirs should still be safe
 	result := runUpdateSync(hubDir, repoDir, true)
 	_ = result
 
-	// The data dir should have been skipped, not copied
-	content, err := os.ReadFile(filepath.Join(localData, "COLONY_STATE.json"))
-	if err != nil {
-		t.Fatalf("failed to read local data file: %v", err)
-	}
-	if string(content) != string(localDataContent) {
-		t.Errorf("protected data/ was overwritten\ngot:  %s\nwant: %s", string(content), string(localDataContent))
+	for dir, fixture := range fixtures {
+		content, err := os.ReadFile(filepath.Join(localAether, dir, fixture.name))
+		if err != nil {
+			t.Fatalf("failed to read local %s file: %v", dir, err)
+		}
+		if string(content) != string(fixture.localContent) {
+			t.Errorf("protected %s/ was overwritten\ngot:  %s\nwant: %s", dir, string(content), string(fixture.localContent))
+		}
 	}
 }
 
@@ -928,7 +974,7 @@ func TestUpdateSyncForceDoesNotRemoveProtectedStale(t *testing.T) {
 	hubDir := t.TempDir()
 	repoDir := t.TempDir()
 
-	// Hub has no data/ directory at all
+	// Hub has no protected local-only directories at all
 	hubSystem := filepath.Join(hubDir, "system")
 	if err := os.MkdirAll(hubSystem, 0755); err != nil {
 		t.Fatalf("failed to create hub system: %v", err)
@@ -937,27 +983,31 @@ func TestUpdateSyncForceDoesNotRemoveProtectedStale(t *testing.T) {
 		t.Fatalf("failed to write hub file: %v", err)
 	}
 
-	// Local has a data/ directory with user files
 	localAether := filepath.Join(repoDir, ".aether")
-	localData := filepath.Join(localAether, "data")
-	if err := os.MkdirAll(localData, 0755); err != nil {
-		t.Fatalf("failed to create local data dir: %v", err)
-	}
 	userFile := []byte(`{"user":"data"}`)
-	if err := os.WriteFile(filepath.Join(localData, "user.json"), userFile, 0644); err != nil {
-		t.Fatalf("failed to write local user file: %v", err)
+	protectedDirs := []string{"archive", "backups", "chambers", "data", "dreams", "oracle"}
+	for _, dir := range protectedDirs {
+		localDir := filepath.Join(localAether, dir)
+		if err := os.MkdirAll(localDir, 0755); err != nil {
+			t.Fatalf("failed to create local %s dir: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(localDir, "user.json"), userFile, 0644); err != nil {
+			t.Fatalf("failed to write local %s user file: %v", dir, err)
+		}
 	}
 
 	// Force sync should NOT remove files in protected dirs
 	result := runUpdateSync(hubDir, repoDir, true)
 	_ = result
 
-	content, err := os.ReadFile(filepath.Join(localData, "user.json"))
-	if err != nil {
-		t.Fatalf("protected user file was removed: %v", err)
-	}
-	if string(content) != string(userFile) {
-		t.Errorf("protected user file was modified\ngot:  %s\nwant: %s", string(content), string(userFile))
+	for _, dir := range protectedDirs {
+		content, err := os.ReadFile(filepath.Join(localAether, dir, "user.json"))
+		if err != nil {
+			t.Fatalf("protected %s user file was removed: %v", dir, err)
+		}
+		if string(content) != string(userFile) {
+			t.Errorf("protected %s user file was modified\ngot:  %s\nwant: %s", dir, string(content), string(userFile))
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- exclude ignored sync artifacts (`.DS_Store`, `node_modules`) from install/publish/update flows and clean stale copies during force syncs
- remove stale local-only directories from channel hubs while preserving repo-local state directories during downstream `update --force`
- update the v1.6 handoff/context with Phase 7 stable/dev publish rules and verification status

## Verification

- `go test ./cmd -run 'TestSyncDirSkipsDSStoreAndRemovesStaleDSStore|TestSyncDirToHubSkipsIgnoredAndExcludedArtifacts|TestRunUpdateSyncCopiesNarratorPackageButSkipsNodeModules|TestUpdateSyncPreservesProtectedDirs|TestUpdateSyncForceDoesNotRemoveProtectedStale' -count=1`
- `go test ./... -count=1`
- `go test ./... -race -count=1 -timeout 600s`
- `go vet ./...`
- `go build ./cmd/aether`
- `git diff --check`
- `npm --prefix .aether/ts ci`
- `npm --prefix .aether/ts run typecheck`
- `npm --prefix .aether/ts test`
- `npm --prefix .aether/ts run build`
- `git diff --exit-code -- .aether/ts/dist/narrator.js`
- `npm --prefix npm test`
- `npm pack --dry-run` from `npm/`
- `go run ./cmd/aether publish --channel stable --binary-dest "$HOME/.local/bin"`
- `go run ./cmd/aether publish --channel dev --binary-dest "$HOME/.local/bin"`
- `AETHER_OUTPUT_MODE=json aether integrity --source --json`
- `AETHER_OUTPUT_MODE=json aether-dev integrity --source --channel dev --json`
- downstream stable/dev `update --force` smoke: narrator synced, stale `.DS_Store` and `node_modules` removed, `archive/` and `chambers/` preserved, binary mode unchanged
- runtime smokes: JSON mode parseable and ceremony-free, visual mode emits ceremony frame, missing Node fallback does not crash