### PR TITLE
Fix stale build artifacts after dispatch completion

### DIFF
--- a/cmd/codex_build.go
+++ b/cmd/codex_build.go
@@ -274,6 +274,8 @@ func runCodexBuild(root string, phaseNum int, selectedTaskIDs []string, syntheti
 		updatedState.Worktrees = latestState.Worktrees
 	}
 	updatedState.State = colony.StateBUILT
+	reconcileCompletedBuildTasks(&updatedState, phaseNum, dispatches)
+	updatedPhase = updatedState.Plan.Phases[phaseNum-1]
 	if _, _, err := writeCodexBuildArtifacts(root, updatedState, updatedPhase, buildDirRel, checkpointRel, claimsRel, playbooks, dispatches, startedAt, mode, selectedTaskIDs); err != nil {
 		return nil, err
 	}
@@ -876,6 +878,7 @@ func executeCodexBuildDispatches(ctx context.Context, root string, phase colony.
 			dispatches[idx].Summary = strings.TrimSpace(result.WorkerResult.Summary)
 			dispatches[idx].Blockers = append([]string{}, result.WorkerResult.Blockers...)
 			dispatches[idx].Duration = result.WorkerResult.Duration.Seconds()
+			dispatches[idx].Outputs = buildDispatchClaimOutputs(*result.WorkerResult)
 		}
 		if result.Error != nil && len(dispatches[idx].Blockers) == 0 {
 			dispatches[idx].Blockers = []string{result.Error.Error()}
@@ -991,6 +994,7 @@ func codexBuildDispatchMaps(dispatches []codexBuildDispatch) []map[string]interf
 func writeCodexBuildArtifacts(root string, state colony.ColonyState, phase colony.Phase, buildDirRel, checkpointRel, claimsRel string, playbooks []string, dispatches []codexBuildDispatch, startedAt time.Time, dispatchMode string, selectedTaskIDs []string) ([]string, []codexBuildDispatch, error) {
 	briefPaths := make([]string, 0, len(dispatches))
 	briefOutputs := map[string]string{}
+	finalOutputs := map[string][]string{}
 
 	for i := range dispatches {
 		briefRel := filepath.ToSlash(filepath.Join(buildDirRel, "worker-briefs", fmt.Sprintf("%s.md", dispatches[i].Name)))
@@ -1004,7 +1008,19 @@ func writeCodexBuildArtifacts(root string, state colony.ColonyState, phase colon
 	}
 	sort.Strings(briefPaths)
 
+	if isFinalBuildDispatchMode(dispatchMode) {
+		var err error
+		finalOutputs, dispatches, err = writeCodexBuildOutcomeReports(root, phase, buildDirRel, dispatches, time.Now().UTC(), dispatchMode)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	for i := range dispatches {
+		if outputs := finalOutputs[dispatches[i].Name]; len(outputs) > 0 {
+			dispatches[i].Outputs = outputs
+			continue
+		}
 		if output := briefOutputs[dispatches[i].Name]; output != "" {
 			dispatches[i].Outputs = []string{output}
 		}
@@ -1017,6 +1033,167 @@ func writeCodexBuildArtifacts(root string, state colony.ColonyState, phase colon
 	}
 
 	return briefPaths, dispatches, nil
+}
+
+func buildDispatchClaimOutputs(result codex.WorkerResult) []string {
+	outputs := make([]string, 0, len(result.FilesCreated)+len(result.FilesModified)+len(result.TestsWritten))
+	outputs = append(outputs, result.FilesCreated...)
+	outputs = append(outputs, result.FilesModified...)
+	outputs = append(outputs, result.TestsWritten...)
+	return uniqueSortedStrings(outputs)
+}
+
+func reconcileCompletedBuildTasks(state *colony.ColonyState, phaseNum int, dispatches []codexBuildDispatch) []string {
+	if state == nil || phaseNum < 1 || phaseNum > len(state.Plan.Phases) {
+		return nil
+	}
+	completed := completedBuildTaskIDs(dispatches)
+	if len(completed) == 0 {
+		return nil
+	}
+	taskIDs := make([]string, 0, len(completed))
+	phase := &state.Plan.Phases[phaseNum-1]
+	for idx := range phase.Tasks {
+		taskID := buildTaskID(phase.Tasks[idx], idx)
+		if _, ok := completed[taskID]; !ok {
+			continue
+		}
+		phase.Tasks[idx].Status = colony.TaskCompleted
+		taskIDs = append(taskIDs, taskID)
+	}
+	return uniqueSortedStrings(taskIDs)
+}
+
+func completedBuildTaskIDs(dispatches []codexBuildDispatch) map[string]struct{} {
+	completed := map[string]struct{}{}
+	for _, dispatch := range dispatches {
+		taskID := strings.TrimSpace(dispatch.TaskID)
+		if taskID == "" || strings.TrimSpace(dispatch.Status) != "completed" {
+			continue
+		}
+		completed[taskID] = struct{}{}
+	}
+	return completed
+}
+
+func isFinalBuildDispatchMode(dispatchMode string) bool {
+	mode := strings.ToLower(strings.TrimSpace(dispatchMode))
+	return mode != "" && mode != "plan-only"
+}
+
+func writeCodexBuildOutcomeReports(root string, phase colony.Phase, buildDirRel string, dispatches []codexBuildDispatch, recordedAt time.Time, dispatchMode string) (map[string][]string, []codexBuildDispatch, error) {
+	outputsByName := make(map[string][]string, len(dispatches))
+	for i := range dispatches {
+		reportRel := filepath.ToSlash(filepath.Join(buildDirRel, "worker-reports", fmt.Sprintf("%s.md", dispatches[i].Name)))
+		claimedOutputs := nonAssignmentBuildOutputs(dispatches[i].Outputs)
+		content := renderCodexBuildWorkerOutcomeReport(root, phase, dispatches[i], claimedOutputs, recordedAt, dispatchMode)
+		if err := store.AtomicWrite(reportRel, []byte(content)); err != nil {
+			return nil, nil, fmt.Errorf("failed to write worker outcome report for %s: %w", dispatches[i].Name, err)
+		}
+		reportPath := displayDataPath(reportRel)
+		outputsByName[dispatches[i].Name] = finalBuildOutputPaths(reportPath, claimedOutputs)
+		dispatches[i].Outputs = outputsByName[dispatches[i].Name]
+	}
+	return outputsByName, dispatches, nil
+}
+
+func nonAssignmentBuildOutputs(outputs []string) []string {
+	filtered := make([]string, 0, len(outputs))
+	for _, output := range outputs {
+		output = strings.TrimSpace(output)
+		if output == "" || strings.Contains(filepath.ToSlash(output), "/worker-briefs/") {
+			continue
+		}
+		filtered = append(filtered, output)
+	}
+	return uniqueSortedStrings(filtered)
+}
+
+func finalBuildOutputPaths(reportPath string, claimedOutputs []string) []string {
+	rest := uniqueSortedStrings(claimedOutputs)
+	outputs := []string{strings.TrimSpace(reportPath)}
+	for _, output := range rest {
+		if output == "" || output == reportPath {
+			continue
+		}
+		outputs = append(outputs, output)
+	}
+	return outputs
+}
+
+func renderCodexBuildWorkerOutcomeReport(root string, phase colony.Phase, dispatch codexBuildDispatch, claimedOutputs []string, recordedAt time.Time, dispatchMode string) string {
+	var b strings.Builder
+	b.WriteString("# Worker Outcome: ")
+	b.WriteString(dispatch.Name)
+	b.WriteString("\n\n")
+	b.WriteString("## Assignment\n")
+	b.WriteString("- Phase: ")
+	b.WriteString(strconv.Itoa(phase.ID))
+	if phase.Name != "" {
+		b.WriteString(" - ")
+		b.WriteString(phase.Name)
+	}
+	b.WriteString("\n")
+	b.WriteString("- Caste: ")
+	b.WriteString(dispatch.Caste)
+	b.WriteString("\n")
+	if dispatch.TaskID != "" {
+		b.WriteString("- Task ID: ")
+		b.WriteString(dispatch.TaskID)
+		b.WriteString("\n")
+	}
+	b.WriteString("- Task: ")
+	b.WriteString(dispatch.Task)
+	b.WriteString("\n")
+	if root != "" {
+		b.WriteString("- Root: ")
+		b.WriteString(root)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n## Recorded Outcome\n")
+	b.WriteString("- Status: ")
+	b.WriteString(strings.TrimSpace(dispatch.Status))
+	if strings.TrimSpace(dispatch.Status) == "" {
+		b.WriteString("unknown")
+	}
+	b.WriteString("\n")
+	b.WriteString("- Dispatch mode: ")
+	b.WriteString(strings.TrimSpace(dispatchMode))
+	b.WriteString("\n")
+	b.WriteString("- Recorded at: ")
+	b.WriteString(recordedAt.UTC().Format(time.RFC3339))
+	b.WriteString("\n")
+	if dispatch.Duration > 0 {
+		b.WriteString("- Duration seconds: ")
+		b.WriteString(strconv.FormatFloat(dispatch.Duration, 'f', 3, 64))
+		b.WriteString("\n")
+	}
+	if summary := strings.TrimSpace(dispatch.Summary); summary != "" {
+		b.WriteString("- Summary: ")
+		b.WriteString(summary)
+		b.WriteString("\n")
+	}
+	if len(dispatch.Blockers) > 0 {
+		b.WriteString("- Blockers:\n")
+		for _, blocker := range dispatch.Blockers {
+			b.WriteString("  - ")
+			b.WriteString(blocker)
+			b.WriteString("\n")
+		}
+	} else {
+		b.WriteString("- Blockers: none\n")
+	}
+	if len(claimedOutputs) > 0 {
+		b.WriteString("- Claimed artifacts:\n")
+		for _, output := range claimedOutputs {
+			b.WriteString("  - ")
+			b.WriteString(output)
+			b.WriteString("\n")
+		}
+	} else {
+		b.WriteString("- Claimed artifacts: none reported\n")
+	}
+	return b.String()
 }
 
 func rollbackCodexBuildFailure(previous colony.ColonyState, phaseNum int, startedAt time.Time, dispatchErr error) {

--- a/cmd/codex_build_finalize.go
+++ b/cmd/codex_build_finalize.go
@@ -190,6 +190,7 @@ func runCodexBuildFinalize(root string, phaseNum int, completion codexExternalBu
 	updatedState := state
 	applyCodexBuildState(&updatedState, phaseNum, startedAt, selectedTaskIDs)
 	updatedState.State = colony.StateBUILT
+	reconcileCompletedBuildTasks(&updatedState, phaseNum, dispatches)
 	updatedPhase := updatedState.Plan.Phases[phaseNum-1]
 	updatedState.Events = append(trimmedEvents(updatedState.Events),
 		fmt.Sprintf("%s|build_completed|build-finalize|Phase %d external Task workers recorded", completedAt.Format(time.RFC3339), phaseNum),
@@ -198,6 +199,11 @@ func runCodexBuildFinalize(root string, phaseNum int, completion codexExternalBu
 	claims := completion.claimsOrAggregate(phaseNum, startedAt, dispatches)
 	if err := store.SaveJSON(claimsRel, claims); err != nil {
 		return nil, colony.ColonyState{}, colony.Phase{}, nil, fmt.Errorf("failed to write build claims: %w", err)
+	}
+
+	_, dispatches, err = writeCodexBuildOutcomeReports(root, updatedPhase, buildDirRel, dispatches, completedAt, "external-task")
+	if err != nil {
+		return nil, colony.ColonyState{}, colony.Phase{}, nil, err
 	}
 
 	finalManifest := buildCodexBuildManifest(root, updatedState, updatedPhase, checkpointRel, claimsRel, manifest.Playbooks, dispatches, startedAt, "external-task", selectedTaskIDs, manifest.WorkerBriefs, false)

--- a/cmd/codex_build_test.go
+++ b/cmd/codex_build_test.go
@@ -168,11 +168,33 @@ func TestBuildWritesDispatchArtifactsAndUpdatesState(t *testing.T) {
 	if state.Plan.Phases[0].Status != colony.PhaseInProgress {
 		t.Fatalf("phase status = %s, want in_progress", state.Plan.Phases[0].Status)
 	}
-	if state.Plan.Phases[0].Tasks[0].Status != colony.TaskInProgress {
-		t.Fatalf("task 1 status = %s, want in_progress", state.Plan.Phases[0].Tasks[0].Status)
+	if state.Plan.Phases[0].Tasks[0].Status != colony.TaskCompleted {
+		t.Fatalf("task 1 status = %s, want completed", state.Plan.Phases[0].Tasks[0].Status)
 	}
-	if state.Plan.Phases[0].Tasks[1].Status != colony.TaskPending {
-		t.Fatalf("task 2 status = %s, want pending", state.Plan.Phases[0].Tasks[1].Status)
+	if state.Plan.Phases[0].Tasks[1].Status != colony.TaskCompleted {
+		t.Fatalf("task 2 status = %s, want completed", state.Plan.Phases[0].Tasks[1].Status)
+	}
+	if manifest.Tasks[0].Status != colony.TaskCompleted || manifest.Tasks[1].Status != colony.TaskCompleted {
+		t.Fatalf("manifest task statuses = %s/%s, want completed/completed", manifest.Tasks[0].Status, manifest.Tasks[1].Status)
+	}
+	for _, dispatch := range manifest.Dispatches {
+		if dispatch.TaskID == "" || dispatch.Status != "completed" {
+			continue
+		}
+		if len(dispatch.Outputs) == 0 {
+			t.Fatalf("completed task dispatch %s has no output evidence", dispatch.Name)
+		}
+		outputRel := strings.TrimPrefix(dispatch.Outputs[0], ".aether/data/")
+		outputData, err := os.ReadFile(filepath.Join(dataDir, outputRel))
+		if err != nil {
+			t.Fatalf("read output evidence for %s: %v", dispatch.Name, err)
+		}
+		if !strings.Contains(string(outputData), "## Recorded Outcome") || !strings.Contains(string(outputData), "Status: completed") {
+			t.Fatalf("output evidence for %s is not a final outcome report:\n%s", dispatch.Name, string(outputData))
+		}
+		if strings.Contains(dispatch.Outputs[0], "/worker-briefs/") && !strings.Contains(string(outputData), "## Recorded Outcome") {
+			t.Fatalf("output evidence for %s points to assignment-only worker brief %s", dispatch.Name, dispatch.Outputs[0])
+		}
 	}
 	if len(state.Events) < 2 || !strings.Contains(strings.Join(state.Events[len(state.Events)-2:], "\n"), "build_dispatched|build") {
 		t.Fatalf("expected build_dispatched event, got %v", state.Events)
@@ -499,6 +521,9 @@ func TestBuildFinalizeRecordsExternalTaskResultsForContinue(t *testing.T) {
 	if state.BuildStartedAt == nil {
 		t.Fatal("expected BuildStartedAt to be set")
 	}
+	if state.Plan.Phases[0].Tasks[0].Status != colony.TaskCompleted {
+		t.Fatalf("task status = %s, want completed", state.Plan.Phases[0].Tasks[0].Status)
+	}
 
 	var finalManifest codexBuildManifest
 	if err := store.LoadJSON("build/phase-1/manifest.json", &finalManifest); err != nil {
@@ -513,9 +538,26 @@ func TestBuildFinalizeRecordsExternalTaskResultsForContinue(t *testing.T) {
 	if len(finalManifest.Dispatches) != len(manifest.Dispatches) {
 		t.Fatalf("final manifest dispatches = %d, want %d", len(finalManifest.Dispatches), len(manifest.Dispatches))
 	}
+	if len(finalManifest.Tasks) != 1 || finalManifest.Tasks[0].Status != colony.TaskCompleted {
+		t.Fatalf("final manifest task status = %+v, want completed", finalManifest.Tasks)
+	}
 	for _, dispatch := range finalManifest.Dispatches {
 		if dispatch.Status != "completed" {
 			t.Fatalf("dispatch %s status = %s, want completed", dispatch.Name, dispatch.Status)
+		}
+		if dispatch.TaskID == "" {
+			continue
+		}
+		if len(dispatch.Outputs) == 0 {
+			t.Fatalf("completed task dispatch %s has no output evidence", dispatch.Name)
+		}
+		outputRel := strings.TrimPrefix(dispatch.Outputs[0], ".aether/data/")
+		outputData, err := os.ReadFile(filepath.Join(dataDir, outputRel))
+		if err != nil {
+			t.Fatalf("read output evidence for %s: %v", dispatch.Name, err)
+		}
+		if !strings.Contains(string(outputData), "## Recorded Outcome") || !strings.Contains(string(outputData), "wrapper-evidence.txt") {
+			t.Fatalf("output evidence for %s does not contain final outcome evidence:\n%s", dispatch.Name, string(outputData))
 		}
 	}
 
@@ -664,8 +706,8 @@ func TestBuildSupportsTaskScopedRedispatch(t *testing.T) {
 	if state.Plan.Phases[0].Tasks[0].Status != colony.TaskCompleted {
 		t.Fatalf("task 1 status = %s, want completed", state.Plan.Phases[0].Tasks[0].Status)
 	}
-	if state.Plan.Phases[0].Tasks[1].Status != colony.TaskInProgress {
-		t.Fatalf("task 2 status = %s, want in_progress", state.Plan.Phases[0].Tasks[1].Status)
+	if state.Plan.Phases[0].Tasks[1].Status != colony.TaskCompleted {
+		t.Fatalf("task 2 status = %s, want completed", state.Plan.Phases[0].Tasks[1].Status)
 	}
 }
 
@@ -746,11 +788,11 @@ func TestBuildRecoversMissingPlanFromPersistedPlanningArtifact(t *testing.T) {
 	if state.Plan.Phases[2].Status != colony.PhaseInProgress {
 		t.Fatalf("phase 3 status = %s, want in_progress", state.Plan.Phases[2].Status)
 	}
-	if state.Plan.Phases[2].Tasks[0].Status != colony.TaskInProgress {
-		t.Fatalf("phase 3 task 1 status = %s, want in_progress", state.Plan.Phases[2].Tasks[0].Status)
+	if state.Plan.Phases[2].Tasks[0].Status != colony.TaskCompleted {
+		t.Fatalf("phase 3 task 1 status = %s, want completed", state.Plan.Phases[2].Tasks[0].Status)
 	}
-	if state.Plan.Phases[2].Tasks[1].Status != colony.TaskInProgress {
-		t.Fatalf("phase 3 task 2 status = %s, want in_progress", state.Plan.Phases[2].Tasks[1].Status)
+	if state.Plan.Phases[2].Tasks[1].Status != colony.TaskCompleted {
+		t.Fatalf("phase 3 task 2 status = %s, want completed", state.Plan.Phases[2].Tasks[1].Status)
 	}
 }
 

--- a/cmd/codex_continue.go
+++ b/cmd/codex_continue.go
@@ -250,6 +250,11 @@ func runCodexContinue(root string, options codexContinueOptions) (map[string]int
 	if state.BuildStartedAt == nil && !manifest.Present {
 		return nil, state, colony.Phase{}, nil, nil, false, fmt.Errorf("No active build packet found. Run `aether build <phase>` first.")
 	}
+	if changed, reconcileErr := reconcileContinueCompletedBuildTasks(&state, &phase, &manifest); reconcileErr != nil {
+		return nil, state, colony.Phase{}, nil, nil, false, reconcileErr
+	} else if changed {
+		state.Plan.Phases[currentIdx] = phase
+	}
 
 	// Abandoned build detection: if all dispatches are still "spawned" and the
 	// build started more than 10 minutes ago, the build was abandoned mid-execution.
@@ -607,6 +612,75 @@ func loadCodexContinueManifest(phaseID int) codexContinueManifest {
 		Path:    rel,
 		Data:    manifest,
 	}
+}
+
+func reconcileContinueCompletedBuildTasks(state *colony.ColonyState, phase *colony.Phase, manifest *codexContinueManifest) (bool, error) {
+	if state == nil || phase == nil || manifest == nil || !manifest.Present {
+		return false, nil
+	}
+	completed := completedBuildTaskIDs(manifest.Data.Dispatches)
+	if len(completed) == 0 {
+		return false, nil
+	}
+
+	changedState := false
+	for idx := range phase.Tasks {
+		taskID := buildTaskID(phase.Tasks[idx], idx)
+		if _, ok := completed[taskID]; !ok {
+			continue
+		}
+		if phase.Tasks[idx].Status != colony.TaskCompleted {
+			phase.Tasks[idx].Status = colony.TaskCompleted
+			changedState = true
+		}
+	}
+	for phaseIdx := range state.Plan.Phases {
+		if state.Plan.Phases[phaseIdx].ID != phase.ID {
+			continue
+		}
+		for idx := range state.Plan.Phases[phaseIdx].Tasks {
+			taskID := buildTaskID(state.Plan.Phases[phaseIdx].Tasks[idx], idx)
+			if _, ok := completed[taskID]; !ok {
+				continue
+			}
+			if state.Plan.Phases[phaseIdx].Tasks[idx].Status != colony.TaskCompleted {
+				state.Plan.Phases[phaseIdx].Tasks[idx].Status = colony.TaskCompleted
+				changedState = true
+			}
+		}
+		break
+	}
+
+	changedManifest := false
+	if len(manifest.Data.Tasks) == 0 {
+		manifest.Data.Tasks = codexBuildTaskPlans(*phase)
+		changedManifest = true
+	}
+	for idx := range manifest.Data.Tasks {
+		taskID := strings.TrimSpace(manifest.Data.Tasks[idx].ID)
+		if taskID == "" {
+			continue
+		}
+		if _, ok := completed[taskID]; !ok {
+			continue
+		}
+		if manifest.Data.Tasks[idx].Status != colony.TaskCompleted {
+			manifest.Data.Tasks[idx].Status = colony.TaskCompleted
+			changedManifest = true
+		}
+	}
+
+	if changedState {
+		if err := store.SaveJSON("COLONY_STATE.json", *state); err != nil {
+			return false, fmt.Errorf("failed to reconcile completed build tasks in colony state: %w", err)
+		}
+	}
+	if changedManifest && strings.TrimSpace(manifest.Path) != "" {
+		if err := store.SaveJSON(manifest.Path, manifest.Data); err != nil {
+			return false, fmt.Errorf("failed to reconcile completed build tasks in manifest: %w", err)
+		}
+	}
+	return changedState || changedManifest, nil
 }
 
 type codexContinueReviewSpec struct {
@@ -1276,11 +1350,11 @@ func continueNextCommandForAssessment(assessment codexContinueAssessment) string
 	if strings.TrimSpace(assessment.Recovery.RedispatchCommand) != "" {
 		return assessment.Recovery.RedispatchCommand
 	}
-	if continueAssessmentPrefersReverify(assessment) && strings.TrimSpace(assessment.Recovery.ReverifyCommand) != "" {
-		return assessment.Recovery.ReverifyCommand
-	}
 	if strings.TrimSpace(assessment.Recovery.ReconcileCommand) != "" {
 		return assessment.Recovery.ReconcileCommand
+	}
+	if continueAssessmentPrefersReverify(assessment) && strings.TrimSpace(assessment.Recovery.ReverifyCommand) != "" {
+		return assessment.Recovery.ReverifyCommand
 	}
 	if strings.TrimSpace(assessment.Recovery.ReverifyCommand) != "" {
 		return assessment.Recovery.ReverifyCommand

--- a/cmd/codex_continue.go
+++ b/cmd/codex_continue.go
@@ -95,6 +95,7 @@ type codexVerificationCommands struct {
 
 type codexContinueOptions struct {
 	ReconcileTaskIDs []string
+	WorkerTimeout    time.Duration
 }
 
 // detectAbandonedBuild checks whether all manifest dispatches are stuck at
@@ -309,7 +310,7 @@ func runCodexContinue(root string, options codexContinueOptions) (map[string]int
 		finishRuntimeSpawnRun(runHandle, runStatus, time.Now().UTC())
 	}()
 
-	verification, watcherFlow := runCodexContinueVerification(root, phase, manifest)
+	verification, watcherFlow := runCodexContinueVerification(root, phase, manifest, options.WorkerTimeout)
 	assessment := assessCodexContinue(phase, manifest, verification, options, now)
 	verification = attachContinueClaimVerification(verification, assessment)
 	gates := runCodexContinueGates(phase, manifest, verification, assessment, now)
@@ -355,7 +356,7 @@ func runCodexContinue(root string, options codexContinueOptions) (map[string]int
 		continueReportRel := filepath.ToSlash(filepath.Join("build", fmt.Sprintf("phase-%d", phase.ID), "continue.json"))
 		workerFlow := continueWorkerFlowWithWatcher(nil, watcherFlow)
 		emitContinueCeremonyFlowSequence("aether-continue", phase, workerFlow)
-		nextCommand := continueNextCommandForAssessment(assessment)
+		nextCommand := continueNextCommandForBlocked(assessment, blockers, options)
 		_ = store.SaveJSON(continueReportRel, codexContinueReport{
 			Phase:              phase.ID,
 			GeneratedAt:        now.Format(time.RFC3339),
@@ -403,7 +404,7 @@ func runCodexContinue(root string, options codexContinueOptions) (map[string]int
 		return result, blockedState, phase, nil, nil, false, nil
 	}
 
-	review := runCodexContinueReview(root, phase, manifest, verification, assessment)
+	review := runCodexContinueReview(root, phase, manifest, verification, assessment, options.WorkerTimeout)
 	reviewReportRel := filepath.ToSlash(filepath.Join("build", fmt.Sprintf("phase-%d", phase.ID), "review.json"))
 	if err := store.SaveJSON(reviewReportRel, review); err != nil {
 		return nil, state, phase, nil, nil, false, fmt.Errorf("failed to write review report: %w", err)
@@ -416,7 +417,7 @@ func runCodexContinue(root string, options codexContinueOptions) (map[string]int
 		continueReportRel := filepath.ToSlash(filepath.Join("build", fmt.Sprintf("phase-%d", phase.ID), "continue.json"))
 		workerFlow := continueWorkerFlowWithWatcher(review.Workers, watcherFlow)
 		emitContinueCeremonyFlowSequence("aether-continue", phase, workerFlow)
-		nextCommand := continueNextCommandForAssessment(assessment)
+		nextCommand := continueNextCommandForBlocked(assessment, review.BlockingIssues, options)
 		_ = store.SaveJSON(continueReportRel, codexContinueReport{
 			Phase:              phase.ID,
 			GeneratedAt:        now.Format(time.RFC3339),
@@ -694,7 +695,7 @@ var codexContinueReviewSpecs = []codexContinueReviewSpec{
 	{Caste: "probe", Task: "Probe the verification evidence for missing edge cases, weak tests, or unexercised behavior. Return blocked if test evidence is too weak to trust advancement."},
 }
 
-func runCodexContinueReview(root string, phase colony.Phase, manifest codexContinueManifest, verification codexContinueVerificationReport, assessment codexContinueAssessment) codexContinueReviewReport {
+func runCodexContinueReview(root string, phase colony.Phase, manifest codexContinueManifest, verification codexContinueVerificationReport, assessment codexContinueAssessment, workerTimeout time.Duration) codexContinueReviewReport {
 	report := codexContinueReviewReport{
 		Phase:       phase.ID,
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
@@ -709,7 +710,7 @@ func runCodexContinueReview(root string, phase colony.Phase, manifest codexConti
 		return report
 	}
 
-	dispatches := plannedContinueReviewDispatches(root, phase, manifest, verification, assessment, invoker)
+	dispatches := plannedContinueReviewDispatches(root, phase, manifest, verification, assessment, invoker, workerTimeout)
 	spawnTree := agent.NewSpawnTree(store, "spawn-tree.txt")
 	results, err := dispatchBatchByWaveWithVisuals(
 		context.Background(),
@@ -773,9 +774,10 @@ func runCodexContinueReview(root string, phase colony.Phase, manifest codexConti
 	return report
 }
 
-func plannedContinueReviewDispatches(root string, phase colony.Phase, manifest codexContinueManifest, verification codexContinueVerificationReport, assessment codexContinueAssessment, invoker codex.WorkerInvoker) []codex.WorkerDispatch {
+func plannedContinueReviewDispatches(root string, phase colony.Phase, manifest codexContinueManifest, verification codexContinueVerificationReport, assessment codexContinueAssessment, invoker codex.WorkerInvoker, workerTimeout time.Duration) []codex.WorkerDispatch {
 	capsule := resolveCodexWorkerContext()
 	pheromoneSection := resolvePheromoneSection()
+	timeout := effectiveContinueReviewTimeout(workerTimeout)
 	dispatches := make([]codex.WorkerDispatch, 0, len(codexContinueReviewSpecs))
 	for idx, spec := range codexContinueReviewSpecs {
 		agentName := codexAgentNameForCaste(spec.Caste)
@@ -791,7 +793,7 @@ func plannedContinueReviewDispatches(root string, phase colony.Phase, manifest c
 			SkillSection:     resolveSkillSection(spec.Caste, spec.Task),
 			PheromoneSection: pheromoneSection,
 			Root:             root,
-			Timeout:          continueReviewTimeout,
+			Timeout:          timeout,
 			Wave:             1,
 		})
 	}
@@ -852,7 +854,7 @@ func renderCodexContinueReviewBrief(root string, phase colony.Phase, manifest co
 	return b.String()
 }
 
-func runCodexContinueVerification(root string, phase colony.Phase, manifest codexContinueManifest) (codexContinueVerificationReport, *codexContinueWorkerFlowStep) {
+func runCodexContinueVerification(root string, phase colony.Phase, manifest codexContinueManifest, workerTimeout time.Duration) (codexContinueVerificationReport, *codexContinueWorkerFlowStep) {
 	now := time.Now().UTC()
 	commands := resolveCodexVerificationCommands(root)
 	steps := []codexVerificationStep{
@@ -863,7 +865,7 @@ func runCodexContinueVerification(root string, phase colony.Phase, manifest code
 	}
 	claims := verifyCodexBuildClaims(root, manifest)
 	buildWatcher := evaluateContinueWatcherVerification(manifest)
-	continueWatcher, watcherFlow := runCodexContinueWatcherVerification(root, phase, manifest, steps, claims, buildWatcher)
+	continueWatcher, watcherFlow := runCodexContinueWatcherVerification(root, phase, manifest, steps, claims, buildWatcher, workerTimeout)
 	watcher := continueWatcher
 	if !watcher.Present {
 		watcher = buildWatcher
@@ -898,9 +900,9 @@ func runCodexContinueVerification(root string, phase colony.Phase, manifest code
 	}, watcherFlow
 }
 
-func runCodexContinueWatcherVerification(root string, phase colony.Phase, manifest codexContinueManifest, steps []codexVerificationStep, claims codexClaimVerification, buildWatcher codexWatcherVerification) (codexWatcherVerification, *codexContinueWorkerFlowStep) {
+func runCodexContinueWatcherVerification(root string, phase colony.Phase, manifest codexContinueManifest, steps []codexVerificationStep, claims codexClaimVerification, buildWatcher codexWatcherVerification, workerTimeout time.Duration) (codexWatcherVerification, *codexContinueWorkerFlowStep) {
 	invoker := newCodexWorkerInvoker()
-	dispatch := plannedContinueWatcherDispatch(root, phase, manifest, steps, claims, buildWatcher, invoker)
+	dispatch := plannedContinueWatcherDispatch(root, phase, manifest, steps, claims, buildWatcher, invoker, workerTimeout)
 	if !invoker.IsAvailable(context.Background()) {
 		summary := fmt.Sprintf("continue watcher verification could not start because %s", dispatchAvailabilityMessage(invoker))
 		return codexWatcherVerification{
@@ -1000,7 +1002,7 @@ func runCodexContinueWatcherVerification(root string, phase colony.Phase, manife
 		}
 }
 
-func plannedContinueWatcherDispatch(root string, phase colony.Phase, manifest codexContinueManifest, steps []codexVerificationStep, claims codexClaimVerification, buildWatcher codexWatcherVerification, invoker codex.WorkerInvoker) codex.WorkerDispatch {
+func plannedContinueWatcherDispatch(root string, phase colony.Phase, manifest codexContinueManifest, steps []codexVerificationStep, claims codexClaimVerification, buildWatcher codexWatcherVerification, invoker codex.WorkerInvoker, workerTimeout time.Duration) codex.WorkerDispatch {
 	agentName := codexAgentNameForCaste("watcher")
 	return codex.WorkerDispatch{
 		ID:               fmt.Sprintf("continue-verification-%d", phase.ID),
@@ -1014,7 +1016,7 @@ func plannedContinueWatcherDispatch(root string, phase colony.Phase, manifest co
 		SkillSection:     resolveSkillSection("watcher", "Independent verification before advancement"),
 		PheromoneSection: resolvePheromoneSection(),
 		Root:             root,
-		Timeout:          continueReviewTimeout,
+		Timeout:          effectiveContinueReviewTimeout(workerTimeout),
 		Wave:             1,
 	}
 }
@@ -1312,8 +1314,7 @@ func classifyContinueTaskAssessment(taskID string, statuses []string, verificati
 func tasksNeedingRecovery(tasks []codexContinueTaskAssessment) []string {
 	taskIDs := make([]string, 0, len(tasks))
 	for _, task := range tasks {
-		switch task.Outcome {
-		case "missing", "needs_redispatch", "implemented_unverified", "simulated":
+		if strings.TrimSpace(task.RecoveryAction) == "redispatch" {
 			taskIDs = append(taskIDs, task.TaskID)
 		}
 	}
@@ -1346,6 +1347,17 @@ func buildTargetedRedispatchCommand(phaseID int, taskIDs []string) string {
 	return b.String()
 }
 
+func continueNextCommandForBlocked(assessment codexContinueAssessment, blockers []string, options codexContinueOptions) string {
+	if continueBlockersContainWorkerTimeout(blockers) {
+		return buildContinueTimeoutRecoveryCommand(options)
+	}
+	next := strings.TrimSpace(continueNextCommandForAssessment(assessment))
+	if next == "aether continue" && len(blockers) > 0 {
+		return ""
+	}
+	return next
+}
+
 func continueNextCommandForAssessment(assessment codexContinueAssessment) string {
 	if strings.TrimSpace(assessment.Recovery.RedispatchCommand) != "" {
 		return assessment.Recovery.RedispatchCommand
@@ -1360,6 +1372,52 @@ func continueNextCommandForAssessment(assessment codexContinueAssessment) string
 		return assessment.Recovery.ReverifyCommand
 	}
 	return "aether continue"
+}
+
+func continueBlockersContainWorkerTimeout(blockers []string) bool {
+	for _, blocker := range blockers {
+		lower := strings.ToLower(strings.TrimSpace(blocker))
+		if lower == "" {
+			continue
+		}
+		if (strings.Contains(lower, "worker timeout") || strings.Contains(lower, "timed out") || strings.Contains(lower, "timeout")) &&
+			(strings.Contains(lower, "watcher") || strings.Contains(lower, "worker") || strings.Contains(lower, "verification")) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildContinueTimeoutRecoveryCommand(options codexContinueOptions) string {
+	timeout := recommendedContinueRecoveryTimeout(options.WorkerTimeout)
+	var b strings.Builder
+	b.WriteString("aether continue --worker-timeout ")
+	b.WriteString(formatDurationForCLI(timeout))
+	for _, taskID := range uniqueSortedStrings(options.ReconcileTaskIDs) {
+		b.WriteString(" --reconcile-task ")
+		b.WriteString(taskID)
+	}
+	return b.String()
+}
+
+func recommendedContinueRecoveryTimeout(current time.Duration) time.Duration {
+	effective := effectiveContinueReviewTimeout(current)
+	recommended := effective * 2
+	minimum := 15 * time.Minute
+	if recommended < minimum {
+		return minimum
+	}
+	return recommended
+}
+
+func formatDurationForCLI(duration time.Duration) string {
+	if duration > 0 && duration%time.Hour == 0 {
+		return fmt.Sprintf("%dh", int(duration/time.Hour))
+	}
+	if duration > 0 && duration%time.Minute == 0 {
+		return fmt.Sprintf("%dm", int(duration/time.Minute))
+	}
+	return duration.String()
 }
 
 func continueAssessmentPrefersReverify(assessment codexContinueAssessment) bool {

--- a/cmd/codex_continue_plan.go
+++ b/cmd/codex_continue_plan.go
@@ -17,6 +17,7 @@ type codexContinueExternalDispatch struct {
 	Name      string   `json:"name"`
 	Task      string   `json:"task"`
 	TaskID    string   `json:"task_id"`
+	Timeout   int      `json:"timeout_seconds,omitempty"`
 	Status    string   `json:"status"`
 	Summary   string   `json:"summary,omitempty"`
 	Blockers  []string `json:"blockers,omitempty"`
@@ -33,6 +34,7 @@ type codexContinuePlanManifest struct {
 	Verification      codexContinueVerificationReport `json:"verification"`
 	Assessment        codexContinueAssessment         `json:"assessment"`
 	ReconcileTaskIDs  []string                        `json:"reconcile_task_ids,omitempty"`
+	WorkerTimeout     int                             `json:"worker_timeout_seconds,omitempty"`
 	Dispatches        []codexContinueExternalDispatch `json:"dispatches"`
 	DispatchMode      string                          `json:"dispatch_mode"`
 	FinalizeSurface   string                          `json:"finalize_surface"`
@@ -78,7 +80,7 @@ func runCodexContinuePlanOnly(root string, options codexContinueOptions) (map[st
 	verification := runCodexContinueVerificationSnapshot(root, phase, manifest, now)
 	assessment := assessCodexContinue(phase, manifest, verification, options, now)
 	verification = attachContinueClaimVerification(verification, assessment)
-	dispatches := plannedExternalContinueDispatches(root, phase, manifest, verification, assessment)
+	dispatches := plannedExternalContinueDispatches(root, phase, manifest, verification, assessment, options.WorkerTimeout)
 	plan := codexContinuePlanManifest{
 		Phase:             phase.ID,
 		PhaseName:         phase.Name,
@@ -88,6 +90,7 @@ func runCodexContinuePlanOnly(root string, options codexContinueOptions) (map[st
 		Verification:      verification,
 		Assessment:        assessment,
 		ReconcileTaskIDs:  append([]string{}, options.ReconcileTaskIDs...),
+		WorkerTimeout:     int(effectiveContinueReviewTimeout(options.WorkerTimeout) / time.Second),
 		Dispatches:        dispatches,
 		DispatchMode:      "plan-only",
 		FinalizeSurface:   "pending",
@@ -111,6 +114,7 @@ func runCodexContinuePlanOnly(root string, options codexContinueOptions) (map[st
 			"source_command":            "AETHER_OUTPUT_MODE=json aether continue --plan-only",
 			"spawn_log_required":        true,
 			"spawn_complete_required":   true,
+			"worker_timeout_seconds":    int(effectiveContinueReviewTimeout(options.WorkerTimeout) / time.Second),
 			"finalize_surface":          "pending",
 			"runtime_verification_only": true,
 		},
@@ -158,7 +162,8 @@ func runCodexContinueVerificationSnapshot(root string, phase colony.Phase, manif
 	}
 }
 
-func plannedExternalContinueDispatches(root string, phase colony.Phase, manifest codexContinueManifest, verification codexContinueVerificationReport, assessment codexContinueAssessment) []codexContinueExternalDispatch {
+func plannedExternalContinueDispatches(root string, phase colony.Phase, manifest codexContinueManifest, verification codexContinueVerificationReport, assessment codexContinueAssessment, workerTimeout time.Duration) []codexContinueExternalDispatch {
+	timeoutSeconds := int(effectiveContinueReviewTimeout(workerTimeout) / time.Second)
 	dispatches := []codexContinueExternalDispatch{
 		{
 			Stage:     "verification",
@@ -168,6 +173,7 @@ func plannedExternalContinueDispatches(root string, phase colony.Phase, manifest
 			Name:      deterministicAntName("watcher", fmt.Sprintf("phase:%d:continue:watcher", phase.ID)),
 			Task:      "Independent verification before advancement",
 			TaskID:    fmt.Sprintf("continue-verification-%d", phase.ID),
+			Timeout:   timeoutSeconds,
 			Status:    "planned",
 			Brief:     renderCodexContinueWatcherBrief(root, phase, manifest, verification.Steps, verification.Claims, verification.Watcher),
 		},
@@ -181,6 +187,7 @@ func plannedExternalContinueDispatches(root string, phase colony.Phase, manifest
 			Name:      deterministicAntName(spec.Caste, fmt.Sprintf("phase:%d:continue:%s", phase.ID, spec.Caste)),
 			Task:      continueReviewTaskForCaste(spec.Caste),
 			TaskID:    fmt.Sprintf("continue-review-%s", spec.Caste),
+			Timeout:   timeoutSeconds,
 			Status:    "planned",
 			Brief:     renderCodexContinueReviewBrief(root, phase, manifest, verification, assessment, spec),
 		})

--- a/cmd/codex_continue_test.go
+++ b/cmd/codex_continue_test.go
@@ -1343,8 +1343,9 @@ func TestContinueBlocksWhenContinueWatcherRejectsPhase(t *testing.T) {
 	if advanced, _ := result["advanced"].(bool); advanced {
 		t.Fatalf("expected advanced:false, got %v", result)
 	}
-	if next := result["next"].(string); next != "aether continue" {
-		t.Fatalf("next = %q, want aether continue when the continue watcher blocks advancement", next)
+	wantNext := "aether continue --reconcile-task " + taskID
+	if next := result["next"].(string); next != wantNext {
+		t.Fatalf("next = %q, want %q when blockers are unchanged", next, wantNext)
 	}
 
 	verification := result["verification"].(map[string]interface{})

--- a/cmd/codex_continue_test.go
+++ b/cmd/codex_continue_test.go
@@ -1343,9 +1343,8 @@ func TestContinueBlocksWhenContinueWatcherRejectsPhase(t *testing.T) {
 	if advanced, _ := result["advanced"].(bool); advanced {
 		t.Fatalf("expected advanced:false, got %v", result)
 	}
-	wantNext := "aether continue --reconcile-task " + taskID
-	if next := result["next"].(string); next != wantNext {
-		t.Fatalf("next = %q, want %q when blockers are unchanged", next, wantNext)
+	if next := result["next"].(string); next != "" {
+		t.Fatalf("next = %q, want empty guidance so blocked watcher output does not suggest an identical retry", next)
 	}
 
 	verification := result["verification"].(map[string]interface{})
@@ -2679,12 +2678,14 @@ type continueWatcherTestInvoker struct {
 	watcherSummary string
 	watcherCalls   int
 	watcherName    string
+	timeouts       []time.Duration
 }
 
 func (f *continueWatcherTestInvoker) Invoke(ctx context.Context, config codex.WorkerConfig) (codex.WorkerResult, error) {
 	if config.Caste == "watcher" {
 		f.watcherCalls++
 		f.watcherName = config.WorkerName
+		f.timeouts = append(f.timeouts, config.Timeout)
 		status := strings.TrimSpace(f.watcherStatus)
 		if status == "" {
 			status = "completed"
@@ -2728,6 +2729,76 @@ func (i *continueUnavailableInvoker) Invoke(ctx context.Context, config codex.Wo
 func (i *continueUnavailableInvoker) IsAvailable(ctx context.Context) bool { return false }
 
 func (i *continueUnavailableInvoker) ValidateAgent(path string) error { return nil }
+
+func TestContinueCommandExposesWorkerTimeoutFlag(t *testing.T) {
+	if continueCmd.Flags().Lookup("worker-timeout") == nil {
+		t.Fatal("expected continue command to expose --worker-timeout")
+	}
+}
+
+func TestContinueWatcherUsesWorkerTimeoutOverride(t *testing.T) {
+	t.Setenv("AETHER_OUTPUT_MODE", "json")
+	saveGlobals(t)
+	resetRootCmd(t)
+
+	dataDir := setupBuildFlowTest(t)
+	root := filepath.Dir(filepath.Dir(dataDir))
+	withTestWorkspace(t, root)
+	withWorkingDir(t, root)
+
+	goal := "Continue watcher honors timeout override"
+	now := time.Now().UTC()
+	taskID := "1.1"
+	nextTaskID := "2.1"
+	createTestColonyState(t, dataDir, colony.ColonyState{
+		Version:        "3.0",
+		Goal:           &goal,
+		State:          colony.StateBUILT,
+		CurrentPhase:   1,
+		BuildStartedAt: &now,
+		Plan: colony.Plan{
+			Phases: []colony.Phase{
+				{
+					ID:     1,
+					Name:   "Timeout override phase",
+					Status: colony.PhaseInProgress,
+					Tasks:  []colony.Task{{ID: &taskID, Goal: "Verify with override", Status: colony.TaskInProgress}},
+				},
+				{
+					ID:     2,
+					Name:   "Next phase",
+					Status: colony.PhasePending,
+					Tasks:  []colony.Task{{ID: &nextTaskID, Goal: "Advance after override", Status: colony.TaskPending}},
+				},
+			},
+		},
+	})
+
+	seedContinueBuildPacket(t, dataDir, 1, "Timeout override phase", goal, []codexBuildDispatch{
+		{Stage: "wave", Wave: 1, Caste: "builder", Name: "Forge-391", Task: "Verify with override", Status: "completed", TaskID: taskID},
+		{Stage: "verification", Caste: "watcher", Name: "Keen-build-392", Task: "Build-time verification", Status: "completed"},
+	})
+
+	invoker := &continueWatcherTestInvoker{
+		watcherStatus:  "completed",
+		watcherSummary: "Continue watcher completed with override",
+	}
+	originalInvoker := newCodexWorkerInvoker
+	newCodexWorkerInvoker = func() codex.WorkerInvoker { return invoker }
+	t.Cleanup(func() { newCodexWorkerInvoker = originalInvoker })
+
+	rootCmd.SetArgs([]string{"continue", "--worker-timeout", "17m"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("continue returned error: %v", err)
+	}
+
+	if len(invoker.timeouts) == 0 {
+		t.Fatal("expected watcher timeout to be recorded")
+	}
+	if got := invoker.timeouts[0]; got != 17*time.Minute {
+		t.Fatalf("watcher timeout = %s, want 17m", got)
+	}
+}
 
 // TestContinue_BlocksOnVerifiedPartial verifies that a phase with a
 // non-completed worker does NOT advance even when verification steps pass.
@@ -2871,6 +2942,9 @@ func TestContinue_BlocksOnWatcherTimeout(t *testing.T) {
 	}
 	if advanced, _ := result["advanced"].(bool); advanced {
 		t.Fatalf("expected advanced:false on watcher timeout, got %v", result)
+	}
+	if next := result["next"].(string); next != "aether continue --worker-timeout 30m" {
+		t.Fatalf("next = %q, want timeout recovery command", next)
 	}
 
 	verification := result["verification"].(map[string]interface{})

--- a/cmd/codex_dispatch_contract.go
+++ b/cmd/codex_dispatch_contract.go
@@ -11,7 +11,7 @@ var (
 	planningScoutTimeout       = 15 * time.Minute
 	planningRouteSetterTimeout = 15 * time.Minute
 	surveyorDispatchTimeout    = 5 * time.Minute
-	continueReviewTimeout      = 5 * time.Minute
+	continueReviewTimeout      = 15 * time.Minute
 )
 
 func effectivePlanningDispatchTimeout(override time.Duration) time.Duration {
@@ -26,6 +26,13 @@ func effectiveSurveyorDispatchTimeout(override time.Duration) time.Duration {
 		return override
 	}
 	return surveyorDispatchTimeout
+}
+
+func effectiveContinueReviewTimeout(override time.Duration) time.Duration {
+	if override > 0 {
+		return override
+	}
+	return continueReviewTimeout
 }
 
 type codexDispatchContract struct {

--- a/cmd/codex_visuals_test.go
+++ b/cmd/codex_visuals_test.go
@@ -505,7 +505,7 @@ func TestContinueBlockedVisualOutputShowsWorkerFlow(t *testing.T) {
 		"Continue Worker Flow",
 		"Continue watcher rejected the phase",
 		"blocked",
-		"aether continue",
+		"aether continue --reconcile-task 1.1",
 		"A R T I F A C T S",
 		".aether/data/build/phase-1/verification.json",
 		".aether/data/build/phase-1/gates.json",
@@ -516,8 +516,8 @@ func TestContinueBlockedVisualOutputShowsWorkerFlow(t *testing.T) {
 			t.Errorf("blocked continue visual output missing %q\n%s", want, output)
 		}
 	}
-	if strings.Contains(output, "--reconcile-task") {
-		t.Fatalf("expected blocked continue next step to stay on plain re-verification, got:\n%s", output)
+	if strings.Contains(output, "Run `aether continue` to recover the blocked work") {
+		t.Fatalf("blocked continue suggested the identical no-op retry:\n%s", output)
 	}
 	if strings.Contains(output, "Forge-141 [builder] completed") {
 		t.Fatalf("expected blocked continue worker flow to avoid builder closure entries, got:\n%s", output)

--- a/cmd/codex_visuals_test.go
+++ b/cmd/codex_visuals_test.go
@@ -505,7 +505,7 @@ func TestContinueBlockedVisualOutputShowsWorkerFlow(t *testing.T) {
 		"Continue Worker Flow",
 		"Continue watcher rejected the phase",
 		"blocked",
-		"aether continue --reconcile-task 1.1",
+		"Fix the blocking issues, then run `aether continue` again.",
 		"A R T I F A C T S",
 		".aether/data/build/phase-1/verification.json",
 		".aether/data/build/phase-1/gates.json",

--- a/cmd/codex_workflow_cmds.go
+++ b/cmd/codex_workflow_cmds.go
@@ -132,10 +132,16 @@ var continueCmd = &cobra.Command{
 	Short: "Verify the active build packet, close dispatched workers, and advance honestly",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		workerTimeout, err := resolveWorkerTimeoutFlag(cmd)
+		if err != nil {
+			outputError(1, err.Error(), nil)
+			return nil
+		}
 		planOnly, _ := cmd.Flags().GetBool("plan-only")
 		if planOnly {
 			result, state, phase, dispatches, err := runCodexContinuePlanOnly(skillWorkspaceRoot(), codexContinueOptions{
 				ReconcileTaskIDs: normalizeCLIStringList(mustGetStringArray(cmd, "reconcile-task")),
+				WorkerTimeout:    workerTimeout,
 			})
 			if err != nil {
 				outputError(1, err.Error(), nil)
@@ -147,6 +153,7 @@ var continueCmd = &cobra.Command{
 
 		result, state, phase, nextPhase, housekeeping, final, err := runCodexContinue(skillWorkspaceRoot(), codexContinueOptions{
 			ReconcileTaskIDs: normalizeCLIStringList(mustGetStringArray(cmd, "reconcile-task")),
+			WorkerTimeout:    workerTimeout,
 		})
 		if err != nil {
 			outputError(1, err.Error(), nil)
@@ -626,6 +633,7 @@ func init() {
 	buildFinalizeCmd.Flags().String("completion-file", "", "JSON file containing dispatch_manifest and external worker results (use - for stdin)")
 	continueCmd.Flags().StringArray("reconcile-task", nil, "Mark one or more task IDs as manually reconciled before continue gating (repeatable or comma-separated)")
 	continueCmd.Flags().Bool("plan-only", false, "Print the continue verification/review manifest without mutating colony state or spawning review workers")
+	continueCmd.Flags().Duration("worker-timeout", 0, "Override per-worker timeout for continue verification/review dispatches (e.g. 15m)")
 	continueFinalizeCmd.Flags().String("completion-file", "", "JSON file containing continue_manifest and external review worker results (use - for stdin)")
 	preferencesCmd.Flags().Bool("list", false, "List stored preferences")
 

--- a/cmd/recovery_snapshot.go
+++ b/cmd/recovery_snapshot.go
@@ -252,7 +252,9 @@ func loadActiveRecoveryGuidance(state colony.ColonyState) *activeRecoveryGuidanc
 
 	next := strings.TrimSpace(report.Next)
 	if next == "" {
-		next = continueNextCommandForAssessment(codexContinueAssessment{Recovery: report.Recovery})
+		if fallback := continueNextCommandForAssessment(codexContinueAssessment{Recovery: report.Recovery}); fallback != "aether continue" {
+			next = fallback
+		}
 	}
 	summary := strings.TrimSpace(report.Summary)
 	reportPath := displayDataPath(rel)


### PR DESCRIPTION
## Summary
- reconcile completed build dispatch task IDs into both `COLONY_STATE.json` and the phase build manifest
- write final worker outcome reports under `worker-reports/` and point manifest outputs at those reports instead of assignment-only briefs
- let `continue` auto-reconcile stale completed task status when manifest dispatch evidence is sufficient, and avoid no-op retry guidance when blocked

## Verification
- `go test ./cmd -run 'TestBuildWritesDispatchArtifactsAndUpdatesState|TestBuildFinalizeRecordsExternalTaskResultsForContinue|TestContinueBlocksWhenContinueWatcherRejectsPhase|TestContinueBlockedVisualOutputShowsWorkerFlow' -count=1`\n- `go test ./cmd -run 'TestBuildSupportsTaskScopedRedispatch|TestBuildRecoversMissingPlanFromPersistedPlanningArtifact|TestBuildWritesDispatchArtifactsAndUpdatesState|TestBuildFinalizeRecordsExternalTaskResultsForContinue|TestContinueBlocksWhenContinueWatcherRejectsPhase|TestContinueBlockedVisualOutputShowsWorkerFlow' -count=1`\n- `go test ./cmd -count=1`\n- `go test ./... -count=1`\n- `go vet ./...`\n- `go test ./cmd -race -count=1`\n- `go build ./cmd/aether`\n\n## Dev publish\nPublished this commit to the dev channel for local testing:\n- `AETHER_OUTPUT_MODE=json go run ./cmd/aether publish --channel dev --binary-dest "$HOME/.local/bin"`\n- `aether-dev version` -> `1.0.23`\n- `aether-dev version --check` -> binary and hub both `1.0.23`\n- `aether-dev integrity --source --json` -> `overall: ok`