### PR TITLE
Codex/workflow aware skill catalog

### DIFF
--- a/cmd/hook_cmds.go
+++ b/cmd/hook_cmds.go
@@ -24,6 +24,8 @@ type claudeHookInput struct {
 	LastAssistantMessage string                 `json:"last_assistant_message"`
 }
 
+const postResumeStopGracePeriod = 15 * time.Minute
+
 var hookPreToolUseCmd = &cobra.Command{
 	Use:    "hook-pre-tool-use [tool_name] [target]",
 	Short:  "Claude hook: validate edits before tool execution",
@@ -108,6 +110,9 @@ var hookStopCmd = &cobra.Command{
 		if (state.State != colony.StateEXECUTING && state.State != colony.StateBUILT) || state.Paused {
 			return nil
 		}
+		if allowStopAfterRecentResume() {
+			return nil
+		}
 
 		phaseLabel := fmt.Sprintf("phase %d", state.CurrentPhase)
 		if state.CurrentPhase > 0 && state.CurrentPhase <= len(state.Plan.Phases) {
@@ -155,6 +160,27 @@ var hookPreCompactCmd = &cobra.Command{
 		ensureSessionSummary(state, "hook-pre-compact", next, summary)
 		return nil
 	},
+}
+
+func allowStopAfterRecentResume() bool {
+	if store == nil {
+		return false
+	}
+
+	var session colony.SessionFile
+	if err := store.LoadJSON("session.json", &session); err != nil {
+		return false
+	}
+	if session.LastCommand != "resume-colony" {
+		return false
+	}
+
+	resumedAt, err := time.Parse(time.RFC3339, strings.TrimSpace(session.LastCommandAt))
+	if err != nil {
+		return false
+	}
+	age := time.Since(resumedAt)
+	return age >= 0 && age <= postResumeStopGracePeriod
 }
 
 func readClaudeHookInput() claudeHookInput {

--- a/cmd/hook_cmds_test.go
+++ b/cmd/hook_cmds_test.go
@@ -228,6 +228,110 @@ func TestHookStopAllowsPausedActiveExecution(t *testing.T) {
 	}
 }
 
+func TestHookStopAllowsImmediatePostResumeStop(t *testing.T) {
+	saveGlobalsCmd(t)
+	resetRootCmd(t)
+
+	var buf bytes.Buffer
+	stdout = &buf
+	var errBuf bytes.Buffer
+	stderr = &errBuf
+
+	s, tmpDir := newTestStoreCmd(t)
+	defer os.RemoveAll(tmpDir)
+
+	goal := "test resumed hook stop"
+	state := colony.ColonyState{
+		Version:      "1.0",
+		Goal:         &goal,
+		State:        colony.StateBUILT,
+		CurrentPhase: 2,
+		Plan: colony.Plan{
+			Phases: []colony.Phase{
+				{ID: 1, Name: "Phase One", Status: colony.PhaseCompleted},
+				{ID: 2, Name: "Phase Two", Status: colony.PhaseInProgress},
+			},
+		},
+	}
+	if err := s.SaveJSON("COLONY_STATE.json", state); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveJSON("session.json", colony.SessionFile{
+		SessionID:     "resume-hook-test",
+		LastCommand:   "resume-colony",
+		LastCommandAt: time.Now().UTC().Format(time.RFC3339),
+		ColonyGoal:    goal,
+		CurrentPhase:  2,
+		SuggestedNext: "aether continue",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	setHookStdin(t, `{"hook_event_name":"Stop","stop_hook_active":false}`)
+	rootCmd.SetArgs([]string{"hook-stop"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("hook-stop returned error: %v", err)
+	}
+
+	if got := strings.TrimSpace(buf.String()); got != "" {
+		t.Fatalf("expected immediate post-resume stop to allow without stdout, got %q", got)
+	}
+}
+
+func TestHookStopBlocksStalePostResumeStop(t *testing.T) {
+	saveGlobalsCmd(t)
+	resetRootCmd(t)
+
+	var buf bytes.Buffer
+	stdout = &buf
+	var errBuf bytes.Buffer
+	stderr = &errBuf
+
+	s, tmpDir := newTestStoreCmd(t)
+	defer os.RemoveAll(tmpDir)
+
+	goal := "test stale resumed hook stop"
+	state := colony.ColonyState{
+		Version:      "1.0",
+		Goal:         &goal,
+		State:        colony.StateBUILT,
+		CurrentPhase: 2,
+		Plan: colony.Plan{
+			Phases: []colony.Phase{
+				{ID: 1, Name: "Phase One", Status: colony.PhaseCompleted},
+				{ID: 2, Name: "Phase Two", Status: colony.PhaseInProgress},
+			},
+		},
+	}
+	if err := s.SaveJSON("COLONY_STATE.json", state); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveJSON("session.json", colony.SessionFile{
+		SessionID:     "stale-resume-hook-test",
+		LastCommand:   "resume-colony",
+		LastCommandAt: time.Now().UTC().Add(-time.Hour).Format(time.RFC3339),
+		ColonyGoal:    goal,
+		CurrentPhase:  2,
+		SuggestedNext: "aether continue",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	setHookStdin(t, `{"hook_event_name":"Stop","stop_hook_active":false}`)
+	rootCmd.SetArgs([]string{"hook-stop"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("hook-stop returned error: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &result); err != nil {
+		t.Fatalf("unmarshal hook output: %v", err)
+	}
+	if result["decision"] != "block" {
+		t.Fatalf("decision = %v, want block", result["decision"])
+	}
+}
+
 func TestHookPreCompactUpdatesSessionSummary(t *testing.T) {
 	saveGlobalsCmd(t)
 	resetRootCmd(t)


### PR DESCRIPTION
## What

- 

## Why

- 

## Risk

- 

## Test

- [ ] `go test ./...`
- [ ] `go vet ./...`
- [ ] Aether install/update path checked if companion files changed
- [ ] Claude Code/OpenCode/Codex surfaces checked if agent or command files changed

## Rollback

- 

## Release notes

- User-facing change: yes/no
- Breaking change: yes/no
- Docs updated: yes/no
