### PR TITLE
Fix Aether 1.0.28 Oracle and Codex release blockers

### DIFF
--- a/cmd/compatibility_cmds.go
+++ b/cmd/compatibility_cmds.go
@@ -32,7 +32,7 @@ var watchCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if store == nil {
 			outputErrorMessage("no store initialized")
-			return nil
+			return renderedErrorExit(1)
 		}
 
 		once, _ := cmd.Flags().GetBool("once")
@@ -66,7 +66,7 @@ var oracleCmd = &cobra.Command{
 		result, err := runOracleCompatibility(skillWorkspaceRoot(), args, depth, confidenceTarget, scope, template)
 		if err != nil {
 			outputError(1, err.Error(), nil)
-			return nil
+			return renderedErrorExit(1)
 		}
 		outputWorkflow(result, renderOracleCompatibilityVisual(result))
 		return nil

--- a/cmd/oracle_loop_test.go
+++ b/cmd/oracle_loop_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -160,6 +161,30 @@ func TestOracleConfidenceTargetRejectsOutOfRange(t *testing.T) {
 				t.Errorf("validateOracleConfidenceTarget(%q) = %q, want error message", tt.value, got)
 			}
 		})
+	}
+}
+
+func TestOracleCommandInvalidConfidenceReturnsRenderedError(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+
+	s, tmpDir := newTestStore(t)
+	defer os.RemoveAll(tmpDir)
+	store = s
+	root := filepath.Dir(filepath.Dir(s.BasePath()))
+	withWorkingDir(t, root)
+
+	rootCmd.SetArgs([]string{"oracle", "--confidence-target", "0", "test topic"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected oracle command to return rendered error for invalid confidence target")
+	}
+	var rendered renderedCommandError
+	if !errors.As(err, &rendered) {
+		t.Fatalf("expected renderedCommandError, got %T: %v", err, err)
+	}
+	if rendered.code != 1 {
+		t.Fatalf("rendered error code = %d, want 1", rendered.code)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -204,8 +205,27 @@ func Execute() error {
 	return rootCmd.Execute()
 }
 
+type renderedCommandError struct {
+	code int
+}
+
+func (e renderedCommandError) Error() string {
+	return fmt.Sprintf("command failed after rendering error output with code %d", e.code)
+}
+
+func renderedErrorExit(code int) error {
+	if code <= 0 {
+		code = 1
+	}
+	return renderedCommandError{code: code}
+}
+
 // ExitWithError prints the error to stderr and exits with code 1.
 func ExitWithError(err error) {
+	var renderedErr renderedCommandError
+	if errors.As(err, &renderedErr) {
+		os.Exit(renderedErr.code)
+	}
 	if err != nil {
 		fmt.Fprintln(stderr, "Error:", err.Error())
 	}

--- a/pkg/codex/worker.go
+++ b/pkg/codex/worker.go
@@ -737,7 +737,7 @@ Return ONLY a single JSON object as your final response.
 - Report blockers truthfully. If blocked, explain why in blockers.
 - Include handoff with changed_files, commands_run, verification_status, known_failures, open_decisions, assumptions, next_worker_instructions, do_not_repeat, and freshness.
 - Keep summary concise and concrete.
-- Include artifacts only when the task brief explicitly asks for a named structured artifact.
+- Include artifacts as an object. Use {} unless the task brief gives an explicit schema.
 `, filepath.Clean(root), statusLine))
 }
 
@@ -760,6 +760,7 @@ func workerClaimsSchema() jsonSchema {
 			"files_created",
 			"files_modified",
 			"tests_written",
+			"artifacts",
 			"tool_count",
 			"blockers",
 			"spawns",
@@ -779,7 +780,9 @@ func workerClaimsSchema() jsonSchema {
 			"tests_written":  stringArray,
 			"artifacts": map[string]interface{}{
 				"type":                 "object",
-				"additionalProperties": true,
+				"additionalProperties": false,
+				"properties":           map[string]interface{}{},
+				"required":             []string{},
 			},
 			"tool_count": map[string]interface{}{
 				"type":    "integer",
@@ -790,6 +793,17 @@ func workerClaimsSchema() jsonSchema {
 			"handoff": map[string]interface{}{
 				"type":                 "object",
 				"additionalProperties": false,
+				"required": []string{
+					"changed_files",
+					"commands_run",
+					"verification_status",
+					"known_failures",
+					"open_decisions",
+					"assumptions",
+					"next_worker_instructions",
+					"do_not_repeat",
+					"freshness",
+				},
 				"properties": map[string]interface{}{
 					"changed_files":            stringArray,
 					"commands_run":             stringArray,

--- a/pkg/codex/worker_test.go
+++ b/pkg/codex/worker_test.go
@@ -46,6 +46,63 @@ func TestWorkerConfig_CustomTimeout(t *testing.T) {
 	}
 }
 
+func TestWorkerClaimsSchemaStrictObjects(t *testing.T) {
+	schema := workerClaimsSchema()
+	if !schema.AdditionalProperties {
+		assertStrictSchemaObject(t, map[string]interface{}{
+			"type":                 schema.Type,
+			"additionalProperties": schema.AdditionalProperties,
+			"properties":           schema.Properties,
+		}, "$")
+		return
+	}
+	t.Fatal("root worker claims schema must disallow additional properties")
+}
+
+func assertStrictSchemaObject(t *testing.T, schema map[string]interface{}, path string) {
+	t.Helper()
+	if schema["type"] == "object" {
+		value, ok := schema["additionalProperties"].(bool)
+		if !ok {
+			t.Fatalf("%s object schema missing additionalProperties=false", path)
+		}
+		if value {
+			t.Fatalf("%s object schema allows additional properties", path)
+		}
+	}
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		if schema["type"] == "object" {
+			t.Fatalf("%s object schema missing properties map", path)
+		}
+		return
+	}
+	requiredRaw, ok := schema["required"].([]string)
+	if path == "$" {
+		ok = true
+		requiredRaw = workerClaimsSchema().Required
+	}
+	if !ok {
+		t.Fatalf("%s object schema missing required list", path)
+	}
+	required := map[string]bool{}
+	for _, name := range requiredRaw {
+		required[name] = true
+	}
+	for name := range props {
+		if !required[name] {
+			t.Fatalf("%s object schema required list missing %q", path, name)
+		}
+	}
+	for name, raw := range props {
+		child, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		assertStrictSchemaObject(t, child, path+"."+name)
+	}
+}
+
 // --- FakeInvoker tests ---
 
 func TestFakeInvoker_ReturnsDeterministicResults(t *testing.T) {


### PR DESCRIPTION
## Summary
- make rendered Aether errors exit nonzero so Oracle invalid confidence failures are visible to wrappers and automation
- tighten Codex worker response JSON schema so live Oracle/worker calls satisfy strict schema validation

## Verification
- go test ./... -count=1
- go vet ./...
- go build ./cmd/aether
- git diff --check HEAD~2..HEAD