### PR TITLE
Fix release binary downloader compatibility

### DIFF
--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -86,8 +86,12 @@ func isSupportedPlatform(goos, goarch string) bool {
 	return detectPlatform(goos, goarch) != nil
 }
 
-// archiveFilename returns the goreleaser archive filename for the given version and platform.
+// archiveFilename returns the primary GoReleaser archive filename for the given version and platform.
 func archiveFilename(version, goos, goarch string) string {
+	return fmt.Sprintf("Aether_%s_%s_%s.tar.gz", version, goos, goarch)
+}
+
+func legacyArchiveFilename(version, goos, goarch string) string {
 	ext := ".tar.gz"
 	if goos == "windows" {
 		ext = ".zip"
@@ -95,14 +99,35 @@ func archiveFilename(version, goos, goarch string) string {
 	return fmt.Sprintf("aether_v%s_%s_%s%s", version, goos, goarch, ext)
 }
 
+func archiveFilenameCandidates(version, goos, goarch string) []string {
+	primary := archiveFilename(version, goos, goarch)
+	legacy := legacyArchiveFilename(version, goos, goarch)
+	if primary == legacy {
+		return []string{primary}
+	}
+	return []string{primary, legacy}
+}
+
 // buildArchiveURL constructs the full download URL for the platform archive.
 func buildArchiveURL(version, goos, goarch string) string {
 	return fmt.Sprintf("%s/%s", fmt.Sprintf(baseReleaseURL, version), archiveFilename(version, goos, goarch))
 }
 
+func buildArchiveURLForFile(version, filename string) string {
+	return fmt.Sprintf("%s/%s", fmt.Sprintf(baseReleaseURL, version), filename)
+}
+
 // buildChecksumsURL constructs the URL for the checksums.txt file.
 func buildChecksumsURL(version string) string {
+	return fmt.Sprintf("%s/checksums.txt", fmt.Sprintf(baseReleaseURL, version))
+}
+
+func buildLegacyChecksumsURL(version string) string {
 	return fmt.Sprintf("%s/aether_v%s_checksums.txt", fmt.Sprintf(baseReleaseURL, version), version)
+}
+
+func buildChecksumsURLCandidates(version string) []string {
+	return []string{buildChecksumsURL(version), buildLegacyChecksumsURL(version)}
 }
 
 // binaryName returns the binary name for the given OS.
@@ -181,6 +206,18 @@ func downloadText(url string) (string, error) {
 	return string(data), nil
 }
 
+func downloadFirstText(urls []string) (string, string, error) {
+	var failures []string
+	for _, url := range urls {
+		content, err := downloadText(url)
+		if err == nil {
+			return content, url, nil
+		}
+		failures = append(failures, err.Error())
+	}
+	return "", "", errors.New(strings.Join(failures, "; "))
+}
+
 // HashResult holds the computed SHA-256 hash and path of a downloaded file.
 type HashResult struct {
 	Hash    string
@@ -251,24 +288,33 @@ func DownloadBinary(version, destDir string) (*DownloadResult, error) {
 		)
 	}
 
-	// 2. Construct URLs
-	archiveFile := archiveFilename(version, platform.OS, platform.Arch)
-	archiveURL := buildArchiveURL(version, platform.OS, platform.Arch)
-	checksumsURL := buildChecksumsURL(version)
-
-	// 3. Download checksums
-	checksumsContent, err := downloadText(checksumsURL)
+	// 2. Download checksums. Current releases publish checksums.txt; older
+	// releases used aether_v<version>_checksums.txt.
+	checksumsContent, _, err := downloadFirstText(buildChecksumsURLCandidates(version))
 	if err != nil {
 		return nil, fmt.Errorf("failed to download checksums for v%s: %w", version, err)
 	}
 
-	// 4. Parse expected hash
-	expectedHash, err := parseChecksum(checksumsContent, archiveFile)
-	if err != nil {
-		return nil, fmt.Errorf("checksum for %q not found in checksums.txt: %w", archiveFile, err)
+	// 3. Find the archive name used by this release. Current GoReleaser
+	// archives are Aether_<version>_<os>_<arch>.tar.gz; legacy releases used
+	// aether_v<version>_<os>_<arch> with zip archives on Windows.
+	var archiveFile string
+	var expectedHash string
+	var checksumFailures []string
+	for _, candidate := range archiveFilenameCandidates(version, platform.OS, platform.Arch) {
+		expectedHash, err = parseChecksum(checksumsContent, candidate)
+		if err == nil {
+			archiveFile = candidate
+			break
+		}
+		checksumFailures = append(checksumFailures, err.Error())
 	}
+	if archiveFile == "" {
+		return nil, fmt.Errorf("checksum for supported archive names not found in checksums.txt: %s", strings.Join(checksumFailures, "; "))
+	}
+	archiveURL := buildArchiveURLForFile(version, archiveFile)
 
-	// 5. Download archive to temp file, computing hash during stream
+	// 4. Download archive to temp file, computing hash during stream
 	tmpDir, err := os.MkdirTemp("", "aether-download-*")
 	if err != nil {
 		return nil, fmt.Errorf("create temp dir: %w", err)
@@ -281,7 +327,7 @@ func DownloadBinary(version, destDir string) (*DownloadResult, error) {
 		return nil, fmt.Errorf("failed to download %s: %w", archiveFile, err)
 	}
 
-	// 6. Verify checksum
+	// 5. Verify checksum
 	if hashResult.Hash != expectedHash {
 		return nil, fmt.Errorf(
 			"checksum mismatch for %s: expected %s, got %s",
@@ -289,7 +335,7 @@ func DownloadBinary(version, destDir string) (*DownloadResult, error) {
 		)
 	}
 
-	// 7. Extract binary from archive
+	// 6. Extract binary from archive
 	binName := binaryName(platform.OS)
 	extractDir := filepath.Join(tmpDir, "extract")
 	if err := os.MkdirAll(extractDir, 0755); err != nil {
@@ -300,7 +346,7 @@ func DownloadBinary(version, destDir string) (*DownloadResult, error) {
 		return nil, fmt.Errorf("failed to extract archive: %w", err)
 	}
 
-	// 8. Atomic install: ensure dest dir exists, rename binary into place
+	// 7. Atomic install: ensure dest dir exists, rename binary into place
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return nil, fmt.Errorf("create dest dir %s: %w", destDir, err)
 	}

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -1,8 +1,10 @@
 package downloader
 
 import (
+	"archive/tar"
 	"archive/zip"
 	"bufio"
+	"compress/gzip"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -84,15 +86,15 @@ func TestBuildArchiveURL(t *testing.T) {
 	}{
 		{
 			"1.0.0", "darwin", "amd64",
-			"https://github.com/calcosmic/Aether/releases/download/v1.0.0/aether_v1.0.0_darwin_amd64.tar.gz",
+			"https://github.com/calcosmic/Aether/releases/download/v1.0.0/Aether_1.0.0_darwin_amd64.tar.gz",
 		},
 		{
 			"2.3.0", "linux", "arm64",
-			"https://github.com/calcosmic/Aether/releases/download/v2.3.0/aether_v2.3.0_linux_arm64.tar.gz",
+			"https://github.com/calcosmic/Aether/releases/download/v2.3.0/Aether_2.3.0_linux_arm64.tar.gz",
 		},
 		{
 			"0.1.0", "windows", "amd64",
-			"https://github.com/calcosmic/Aether/releases/download/v0.1.0/aether_v0.1.0_windows_amd64.zip",
+			"https://github.com/calcosmic/Aether/releases/download/v0.1.0/Aether_0.1.0_windows_amd64.tar.gz",
 		},
 	}
 	for _, tc := range tests {
@@ -107,7 +109,7 @@ func TestBuildArchiveURL(t *testing.T) {
 
 func TestBuildChecksumsURL(t *testing.T) {
 	got := buildChecksumsURL("2.5.0")
-	want := "https://github.com/calcosmic/Aether/releases/download/v2.5.0/aether_v2.5.0_checksums.txt"
+	want := "https://github.com/calcosmic/Aether/releases/download/v2.5.0/checksums.txt"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -120,9 +122,9 @@ func TestArchiveFilename(t *testing.T) {
 		arch    string
 		want    string
 	}{
-		{"1.0.0", "darwin", "amd64", "aether_v1.0.0_darwin_amd64.tar.gz"},
-		{"1.0.0", "windows", "amd64", "aether_v1.0.0_windows_amd64.zip"},
-		{"2.0.0", "linux", "arm64", "aether_v2.0.0_linux_arm64.tar.gz"},
+		{"1.0.0", "darwin", "amd64", "Aether_1.0.0_darwin_amd64.tar.gz"},
+		{"1.0.0", "windows", "amd64", "Aether_1.0.0_windows_amd64.tar.gz"},
+		{"2.0.0", "linux", "arm64", "Aether_2.0.0_linux_arm64.tar.gz"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.want, func(t *testing.T) {
@@ -134,12 +136,44 @@ func TestArchiveFilename(t *testing.T) {
 	}
 }
 
+func TestArchiveFilenameCandidatesIncludesLegacyFallback(t *testing.T) {
+	got := archiveFilenameCandidates("1.0.0", "windows", "amd64")
+	want := []string{
+		"Aether_1.0.0_windows_amd64.tar.gz",
+		"aether_v1.0.0_windows_amd64.zip",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d candidates, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("candidate %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBuildChecksumsURLCandidatesIncludesLegacyFallback(t *testing.T) {
+	got := buildChecksumsURLCandidates("2.5.0")
+	want := []string{
+		"https://github.com/calcosmic/Aether/releases/download/v2.5.0/checksums.txt",
+		"https://github.com/calcosmic/Aether/releases/download/v2.5.0/aether_v2.5.0_checksums.txt",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d candidates, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("candidate %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 // --- Checksum Parsing ---
 
 func TestParseChecksums_Found(t *testing.T) {
-	content := "abc123def  aether_v1.0.0_darwin_amd64.tar.gz\n" +
-		"deadbeef  aether_v1.0.0_linux_amd64.tar.gz\n"
-	hash, err := parseChecksum(content, "aether_v1.0.0_darwin_amd64.tar.gz")
+	content := "abc123def  Aether_1.0.0_darwin_amd64.tar.gz\n" +
+		"deadbeef  Aether_1.0.0_linux_amd64.tar.gz\n"
+	hash, err := parseChecksum(content, "Aether_1.0.0_darwin_amd64.tar.gz")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -500,6 +534,93 @@ func TestExtractZipImpl_WithSubdirs(t *testing.T) {
 
 	destBin := filepath.Join(destDir, binName)
 	data, err := os.ReadFile(destBin)
+	if err != nil {
+		t.Fatalf("read dest binary: %v", err)
+	}
+	if string(data) != binContent {
+		t.Errorf("content mismatch: got %q, want %q", string(data), binContent)
+	}
+}
+
+func createTestTarGz(t *testing.T, archivePath, topDir, binName, content string, typeflag byte) {
+	t.Helper()
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create tar.gz: %v", err)
+	}
+	defer file.Close()
+
+	gz := gzip.NewWriter(file)
+	defer gz.Close()
+	tw := tar.NewWriter(gz)
+	defer tw.Close()
+
+	dirHeader := &tar.Header{Name: topDir + "/", Typeflag: tar.TypeDir, Mode: 0755}
+	if err := tw.WriteHeader(dirHeader); err != nil {
+		t.Fatalf("write dir header: %v", err)
+	}
+	header := &tar.Header{
+		Name:     topDir + "/" + binName,
+		Typeflag: typeflag,
+		Mode:     0755,
+		Size:     int64(len(content)),
+	}
+	if err := tw.WriteHeader(header); err != nil {
+		t.Fatalf("write file header: %v", err)
+	}
+	if _, err := tw.Write([]byte(content)); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func TestExtractTarGzImpl_Basic(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "test.tar.gz")
+	stageDir := filepath.Join(tmpDir, "stage")
+	destDir := filepath.Join(tmpDir, "dest")
+	binContent := "fake binary content"
+
+	if err := os.MkdirAll(stageDir, 0755); err != nil {
+		t.Fatalf("mkdir stage: %v", err)
+	}
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+
+	createTestTarGz(t, archivePath, "aether_v1.0.0_darwin_arm64", "aether", binContent, tar.TypeReg)
+
+	if err := extractTarGzImpl(archivePath, stageDir, destDir, "aether"); err != nil {
+		t.Fatalf("extractTarGzImpl returned error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(destDir, "aether"))
+	if err != nil {
+		t.Fatalf("read dest binary: %v", err)
+	}
+	if string(data) != binContent {
+		t.Errorf("content mismatch: got %q, want %q", string(data), binContent)
+	}
+}
+
+func TestExtractTarGzImpl_AcceptsAlternateRegularFileType(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "test.tar.gz")
+	stageDir := filepath.Join(tmpDir, "stage")
+	destDir := filepath.Join(tmpDir, "dest")
+	binContent := "fake binary content"
+
+	if err := os.MkdirAll(stageDir, 0755); err != nil {
+		t.Fatalf("mkdir stage: %v", err)
+	}
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+
+	createTestTarGz(t, archivePath, "aether_v1.0.0_darwin_arm64", "aether", binContent, tar.TypeRegA)
+
+	if err := extractTarGzImpl(archivePath, stageDir, destDir, "aether"); err != nil {
+		t.Fatalf("extractTarGzImpl TypeRegA returned error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(destDir, "aether"))
 	if err != nil {
 		t.Fatalf("read dest binary: %v", err)
 	}

--- a/pkg/downloader/extract.go
+++ b/pkg/downloader/extract.go
@@ -52,7 +52,7 @@ func extractTarGzImpl(archivePath, stageDir, destDir, bin string) error {
 			if err := os.MkdirAll(targetPath, 0755); err != nil {
 				return fmt.Errorf("mkdir: %w", err)
 			}
-		case tar.TypeReg:
+		case tar.TypeReg, tar.TypeRegA:
 			if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
 				return fmt.Errorf("mkdir parent: %w", err)
 			}


### PR DESCRIPTION
## Summary
- prefer current GoReleaser asset names and checksums.txt
- fall back to legacy aether_v<version> asset/checksum names for older releases
- accept both tar regular-file type markers during extraction

## Verification
- go test ./... -count=1
- go vet ./...
- go build ./cmd/aether
- git diff --check HEAD~1..HEAD
- live smoke: aether update --force --download-binary exits 0 against v1.0.28 compatibility assets