### PR TITLE
Align release archive binary naming

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,7 @@ before:
 
 builds:
   - main: ./cmd/aether/
+    binary: aether
     ldflags:
       - -X github.com/calcosmic/Aether/cmd.Version={{.Version}}
     env:

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -628,3 +628,31 @@ func TestExtractTarGzImpl_AcceptsAlternateRegularFileType(t *testing.T) {
 		t.Errorf("content mismatch: got %q, want %q", string(data), binContent)
 	}
 }
+
+func TestExtractTarGzImpl_AcceptsCapitalizedBinaryName(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "test.tar.gz")
+	stageDir := filepath.Join(tmpDir, "stage")
+	destDir := filepath.Join(tmpDir, "dest")
+	binContent := "fake binary content"
+
+	if err := os.MkdirAll(stageDir, 0755); err != nil {
+		t.Fatalf("mkdir stage: %v", err)
+	}
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+
+	createTestTarGz(t, archivePath, "Aether_1.0.0_darwin_arm64", "Aether", binContent, tar.TypeReg)
+
+	if err := extractTarGzImpl(archivePath, stageDir, destDir, "aether"); err != nil {
+		t.Fatalf("extractTarGzImpl capitalized binary returned error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(destDir, "aether"))
+	if err != nil {
+		t.Fatalf("read dest binary: %v", err)
+	}
+	if string(data) != binContent {
+		t.Errorf("content mismatch: got %q, want %q", string(data), binContent)
+	}
+}

--- a/pkg/downloader/extract.go
+++ b/pkg/downloader/extract.go
@@ -84,7 +84,7 @@ func findBinaryInDir(dir, bin string) string {
 		if err != nil || d.IsDir() {
 			return nil
 		}
-		if filepath.Base(path) == bin && found == "" {
+		if strings.EqualFold(filepath.Base(path), bin) && found == "" {
 			found = path
 		}
 		return nil


### PR DESCRIPTION
## Summary
- make GoReleaser archives contain lowercase aether binary
- make downloader extraction tolerate capitalized Aether binaries already present in release archives

## Verification
- go test ./... -count=1
- go vet ./...
- go build ./cmd/aether
- goreleaser check
- git diff --check HEAD~1..HEAD