### PR TITLE
Harden agent supervision and Oracle response recovery

### DIFF
--- a/.aether/commands/continue.yaml
+++ b/.aether/commands/continue.yaml
@@ -37,8 +37,8 @@ wrapper_additions:
     - light: Skip all review agents (fastest, minimal safety net)
     - standard: Probe-only review (default, watcher + probe coverage)
     - heavy: Full quality gauntlet (gatekeeper + auditor + probe)
-    The default is "standard" for intermediate phases. Final phases always use "heavy".
-    Users can override with --verification-depth <light|standard|heavy>.
+    The default is "standard" for intermediate phases. Final phases default to "heavy" when depth is automatic.
+    Users can override any automatic depth, including final phases, with --verification-depth <light|standard|heavy>.
 guardrails:
   - "Do NOT use `--plan-only` or `continue-finalize` for default fast continue."
   - "Do NOT run `aether continue --synthetic` after real wrapper Task agents complete."

--- a/.aether/docs/command-playbooks/build-full.md
+++ b/.aether/docs/command-playbooks/build-full.md
@@ -80,7 +80,11 @@ Check that the LiteLLM proxy is running for model routing:
 
 Run using the Bash tool with description "Checking model proxy...":
 ```bash
-curl -s http://localhost:4000/health | grep -q "healthy" && echo "Proxy healthy" || echo "Proxy not running - workers will use default model"
+if [ -n "$LITELLM_PROXY_URL" ]; then
+  curl -s "${LITELLM_PROXY_URL%/}/health" 2>/dev/null | grep -q "healthy" && echo "Proxy healthy" || echo "Proxy not reachable at $LITELLM_PROXY_URL - workers will use default model"
+else
+  echo "Proxy check skipped - LITELLM_PROXY_URL not set; workers will use default model"
+fi
 ```
 
 If proxy is not healthy, log a warning but continue (workers will fall back to default routing).

--- a/.aether/docs/command-playbooks/build-prep.md
+++ b/.aether/docs/command-playbooks/build-prep.md
@@ -80,7 +80,11 @@ Check that the LiteLLM proxy is running for model routing:
 
 Run using the Bash tool with description "Checking model proxy...":
 ```bash
-curl -s http://localhost:4000/health | grep -q "healthy" && echo "Proxy healthy" || echo "Proxy not running - workers will use default model"
+if [ -n "$LITELLM_PROXY_URL" ]; then
+  curl -s "${LITELLM_PROXY_URL%/}/health" 2>/dev/null | grep -q "healthy" && echo "Proxy healthy" || echo "Proxy not reachable at $LITELLM_PROXY_URL - workers will use default model"
+else
+  echo "Proxy check skipped - LITELLM_PROXY_URL not set; workers will use default model"
+fi
 ```
 
 If proxy is not healthy, log a warning but continue (workers will fall back to default routing).

--- a/.claude/commands/ant-continue.md
+++ b/.claude/commands/ant-continue.md
@@ -21,7 +21,7 @@ AETHER_OUTPUT_MODE=visual aether status
 Then run the fast development continue path directly:
 
 ```
-AETHER_OUTPUT_MODE=visual aether continue --skip-watchers --light $ARGUMENTS
+AETHER_OUTPUT_MODE=visual aether continue --skip-watchers --verification-depth standard $ARGUMENTS
 ```
 
 This is the normal path. Do not ask for a plan-only manifest, spawn wrapper workers, or run `continue-finalize` for default continue.
@@ -36,12 +36,23 @@ The runtime owns deterministic verification and gates. Keep any framing short:
 
 Do not claim gate results before the CLI reports them.
 
+## Verification Depth
+
+Verification depth controls how thorough the continue review is:
+- **light**: Skip all review agents -- fastest, minimal safety net
+- **standard**: Probe-only review (default) -- watcher + probe coverage
+- **heavy**: Full quality gauntlet -- gatekeeper + auditor + probe
+
+The default is "standard" for intermediate phases. Final phases default to "heavy" when depth is automatic.
+Override any automatic depth, including final phases, with `--verification-depth <light|standard|heavy>`.
+The old `--light` and `--heavy` flags still work as backward-compatible aliases.
+
 ## Heavy External Review
 
-Only use this path when the user explicitly requests `--heavy` or when the runtime specifically asks for wrapper-spawned review workers.
+Only use this path when the user explicitly requests `--verification-depth heavy` (or `--heavy`) or when the runtime specifically asks for wrapper-spawned review workers.
 
 1. Run:
-   `AETHER_OUTPUT_MODE=json aether continue --plan-only --heavy $ARGUMENTS`
+   `AETHER_OUTPUT_MODE=json aether continue --plan-only --verification-depth heavy $ARGUMENTS`
 2. Parse `result.continue_manifest`; do not parse visual output.
 3. For each dispatch in `continue_manifest.dispatches`, run `AETHER_OUTPUT_MODE=json aether spawn-log`, spawn the matching platform agent using `subagent_type="{agent_name}"` or equivalent, then run `AETHER_OUTPUT_MODE=json aether spawn-complete`.
 4. Collect terminal worker results into a temporary completion JSON file containing the original `continue_manifest` and a `dispatches` array.

--- a/.claude/commands/ant-verify-castes.md
+++ b/.claude/commands/ant-verify-castes.md
@@ -68,7 +68,11 @@ Run using the Bash tool with description "Checking colony version...": `aether v
 
 Check LiteLLM proxy status:
 ```bash
-curl -s http://localhost:4000/health 2>/dev/null | grep -q "healthy" && echo "✓ Proxy healthy" || echo "⚠ Proxy not running"
+if [ -n "$LITELLM_PROXY_URL" ]; then
+  curl -s "${LITELLM_PROXY_URL%/}/health" 2>/dev/null | grep -q "healthy" && echo "✓ Proxy healthy" || echo "⚠ Proxy not reachable at $LITELLM_PROXY_URL"
+else
+  echo "LiteLLM proxy check skipped (LITELLM_PROXY_URL not set)"
+fi
 ```
 
 ## Step 3: Show Current Model Configuration

--- a/.claude/commands/ant/continue.md
+++ b/.claude/commands/ant/continue.md
@@ -43,8 +43,8 @@ Verification depth controls how thorough the continue review is:
 - **standard**: Probe-only review (default) -- watcher + probe coverage
 - **heavy**: Full quality gauntlet -- gatekeeper + auditor + probe
 
-The default is "standard" for intermediate phases. Final phases always get "heavy".
-Override with `--verification-depth <light|standard|heavy>`.
+The default is "standard" for intermediate phases. Final phases default to "heavy" when depth is automatic.
+Override any automatic depth, including final phases, with `--verification-depth <light|standard|heavy>`.
 The old `--light` and `--heavy` flags still work as backward-compatible aliases.
 
 ## Heavy External Review

--- a/.claude/commands/ant/verify-castes.md
+++ b/.claude/commands/ant/verify-castes.md
@@ -68,7 +68,11 @@ Run using the Bash tool with description "Checking colony version...": `aether v
 
 Check LiteLLM proxy status:
 ```bash
-curl -s http://localhost:4000/health 2>/dev/null | grep -q "healthy" && echo "✓ Proxy healthy" || echo "⚠ Proxy not running"
+if [ -n "$LITELLM_PROXY_URL" ]; then
+  curl -s "${LITELLM_PROXY_URL%/}/health" 2>/dev/null | grep -q "healthy" && echo "✓ Proxy healthy" || echo "⚠ Proxy not reachable at $LITELLM_PROXY_URL"
+else
+  echo "LiteLLM proxy check skipped (LITELLM_PROXY_URL not set)"
+fi
 ```
 
 ## Step 3: Show Current Model Configuration

--- a/.opencode/commands/ant/continue.md
+++ b/.opencode/commands/ant/continue.md
@@ -43,8 +43,8 @@ Verification depth controls how thorough the continue review is:
 - **standard**: Probe-only review (default) -- watcher + probe coverage
 - **heavy**: Full quality gauntlet -- gatekeeper + auditor + probe
 
-The default is "standard" for intermediate phases. Final phases always get "heavy".
-Override with `--verification-depth <light|standard|heavy>`.
+The default is "standard" for intermediate phases. Final phases default to "heavy" when depth is automatic.
+Override any automatic depth, including final phases, with `--verification-depth <light|standard|heavy>`.
 The old `--light` and `--heavy` flags still work as backward-compatible aliases.
 
 ## Heavy External Review

--- a/.opencode/commands/ant/verify-castes.md
+++ b/.opencode/commands/ant/verify-castes.md
@@ -68,7 +68,11 @@ Run using the Bash tool with description "Checking colony version...": `aether v
 
 Check LiteLLM proxy status:
 ```bash
-curl -s http://localhost:4000/health 2>/dev/null | grep -q "healthy" && echo "✓ Proxy healthy" || echo "⚠ Proxy not running"
+if [ -n "$LITELLM_PROXY_URL" ]; then
+  curl -s "${LITELLM_PROXY_URL%/}/health" 2>/dev/null | grep -q "healthy" && echo "✓ Proxy healthy" || echo "⚠ Proxy not reachable at $LITELLM_PROXY_URL"
+else
+  echo "LiteLLM proxy check skipped (LITELLM_PROXY_URL not set)"
+fi
 ```
 
 ## Step 3: Show Current Model Configuration

--- a/cmd/codex_build.go
+++ b/cmd/codex_build.go
@@ -119,6 +119,7 @@ var errRuntimeStateSuperseded = errors.New("runtime state superseded")
 
 type codexBuildOptions struct {
 	WorkerTimeout           time.Duration
+	ParentContext           context.Context
 	Force                   bool
 	LightFlag               bool
 	HeavyFlag               bool
@@ -330,7 +331,11 @@ func runCodexBuildWithOptions(root string, phaseNum int, selectedTaskIDs []strin
 	waveCount := len(waveExecution)
 	parallelWaves := countParallelWaveExecutionPlans(waveExecution)
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	parentCtx := options.ParentContext
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	ctx, cancel := signal.NotifyContext(parentCtx, os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
 	ceremony := newBuildCeremonyEmitter(ctx, root, phase)

--- a/cmd/codex_build_finalize.go
+++ b/cmd/codex_build_finalize.go
@@ -673,16 +673,17 @@ func normalizeClaimPathsToRoot(root string, paths []string) []string {
 }
 
 // findRepoRelativePath searches for a file in the repo that matches the claimed path.
-// Uses git ls-files for fast lookup. If git finds nothing, the file likely doesn't
-// exist in the repo (no unbounded filesystem walk fallback).
+// Uses git ls-files for fast lookup and includes untracked files so newly-created
+// files can satisfy basename-only worker claims before they are staged.
 func findRepoRelativePath(root, claimed string) string {
 	base := filepath.Base(claimed)
 	if base == "." || base == string(filepath.Separator) {
 		return ""
 	}
 
-	// Try git ls-files with basename pattern for fast lookup
-	out, err := exec.Command("git", "-C", root, "ls-files", "--", "*"+base).Output()
+	// Try git ls-files with basename pattern for fast lookup. Include untracked
+	// files because worker-created files are often not staged when continue runs.
+	out, err := exec.Command("git", "-C", root, "ls-files", "--cached", "--others", "--exclude-standard", "--", "*"+base).Output()
 	if err == nil {
 		candidates := parseGitNameOutput(out)
 		if len(candidates) == 1 {

--- a/cmd/codex_build_finalize_test.go
+++ b/cmd/codex_build_finalize_test.go
@@ -142,10 +142,10 @@ func TestMergeExternalBuildResultsWithCodeWritten(t *testing.T) {
 
 	results := []codexExternalBuildWorkerResult{
 		{
-			Name:         "Mason-67",
-			Status:       "code_written",
-			Summary:      "Implemented task 1.1",
-			FilesCreated: []string{"src/main.go"},
+			Name:          "Mason-67",
+			Status:        "code_written",
+			Summary:       "Implemented task 1.1",
+			FilesCreated:  []string{"src/main.go"},
 			FilesModified: []string{"go.mod"},
 		},
 	}
@@ -395,6 +395,24 @@ func TestFindRepoRelativePath(t *testing.T) {
 			t.Errorf("findRepoRelativePath(%q, %q) = %q, want %q", tmp, claimed, got, "deep/nested/dir/target.go")
 		}
 	})
+}
+
+func TestFindRepoRelativePathIncludesUntrackedFiles(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "src", "components"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testFile := filepath.Join(tmp, "src", "components", "AddCardButton.test.tsx")
+	if err := os.WriteFile(testFile, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gitInitForTest(t, tmp)
+
+	got := findRepoRelativePath(tmp, "AddCardButton.test.tsx")
+	if got != "src/components/AddCardButton.test.tsx" {
+		t.Errorf("findRepoRelativePath() = %q, want %q", got, "src/components/AddCardButton.test.tsx")
+	}
 }
 
 func gitInitForTest(t *testing.T, dir string) {

--- a/cmd/codex_continue.go
+++ b/cmd/codex_continue.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/calcosmic/Aether/pkg/agent"
@@ -102,6 +104,7 @@ type codexContinueOptions struct {
 	ReconcileTaskIDs    []string
 	WorkerTimeout       time.Duration
 	VerificationTimeout time.Duration
+	ParentContext       context.Context
 	LightFlag           bool
 	HeavyFlag           bool
 	SkipWatchers        bool
@@ -401,6 +404,12 @@ func runCodexContinue(root string, options codexContinueOptions) (map[string]int
 	if store == nil {
 		return nil, colony.ColonyState{}, colony.Phase{}, nil, nil, false, fmt.Errorf("no store initialized")
 	}
+	parentCtx := options.ParentContext
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	ctx, stopSignals := signal.NotifyContext(parentCtx, os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
 
 	state, err := loadActiveColonyState()
 	if err != nil {
@@ -512,7 +521,7 @@ func runCodexContinue(root string, options codexContinueOptions) (map[string]int
 		progress = NewCeremonyProgress(continueSteps, stdout)
 	}
 
-	verification, watcherFlow := runCodexContinueVerification(root, state, phase, manifest, options.WorkerTimeout, options.VerificationTimeout, options.SkipWatchers)
+	verification, watcherFlow := runCodexContinueVerification(ctx, root, state, phase, manifest, options.WorkerTimeout, options.VerificationTimeout, options.SkipWatchers)
 	assessment := assessCodexContinue(phase, manifest, verification, options, now)
 	verification = attachContinueClaimVerification(verification, assessment)
 	priorGateResults, _ := gateResultsReadPhase(phase.ID)
@@ -534,7 +543,9 @@ func runCodexContinue(root string, options codexContinueOptions) (map[string]int
 			Detail:    c.Detail,
 		})
 	}
-	_ = gateResultsWrite(gateResultEntries)
+	if err := gateResultsWrite(gateResultEntries); err != nil {
+		return nil, state, phase, nil, nil, false, fmt.Errorf("failed to persist gate results: %w", err)
+	}
 
 	// Per-phase gate results persistence (D-14)
 	var phaseGateResults []GateCheckResult
@@ -552,7 +563,9 @@ func runCodexContinue(root string, options codexContinueOptions) (map[string]int
 			Timestamp:       now.Format(time.RFC3339),
 		})
 	}
-	_ = gateResultsWritePhase(phase.ID, phaseGateResults)
+	if err := gateResultsWritePhase(phase.ID, phaseGateResults); err != nil {
+		return nil, state, phase, nil, nil, false, fmt.Errorf("failed to persist phase gate results: %w", err)
+	}
 
 	if tracer != nil && state.RunID != nil {
 		_ = tracer.LogArtifact(*state.RunID, "continue.verification", map[string]interface{}{
@@ -1204,15 +1217,18 @@ func isCodexWorkerAvailable() bool {
 	return invoker.IsAvailable(context.Background())
 }
 
-func runCodexContinueVerification(root string, state colony.ColonyState, phase colony.Phase, manifest codexContinueManifest, workerTimeout time.Duration, verificationTimeout time.Duration, skipWatchers bool) (codexContinueVerificationReport, *codexContinueWorkerFlowStep) {
+func runCodexContinueVerification(ctx context.Context, root string, state colony.ColonyState, phase colony.Phase, manifest codexContinueManifest, workerTimeout time.Duration, verificationTimeout time.Duration, skipWatchers bool) (codexContinueVerificationReport, *codexContinueWorkerFlowStep) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	now := time.Now().UTC()
 	verificationTimeout = effectiveContinueVerificationTimeout(verificationTimeout)
 	commands := resolveCodexVerificationCommands(root)
 	steps := []codexVerificationStep{
-		runVerificationStep(root, "build", commands.Build, verificationTimeout),
-		runVerificationStep(root, "types", commands.Type, verificationTimeout),
-		runVerificationStep(root, "lint", commands.Lint, verificationTimeout),
-		runVerificationStep(root, "tests", commands.Test, verificationTimeout),
+		runVerificationStep(ctx, root, "build", commands.Build, verificationTimeout),
+		runVerificationStep(ctx, root, "types", commands.Type, verificationTimeout),
+		runVerificationStep(ctx, root, "lint", commands.Lint, verificationTimeout),
+		runVerificationStep(ctx, root, "tests", commands.Test, verificationTimeout),
 	}
 	claims := verifyCodexBuildClaims(root, manifest)
 	buildWatcher := evaluateContinueWatcherVerification(manifest)
@@ -1241,7 +1257,7 @@ func runCodexContinueVerification(root string, state colony.ColonyState, phase c
 			"aether-continue")
 		continueWatcher = codexWatcherVerification{Present: true, Passed: true, Status: "skipped", Worker: "auto-skip", Summary: fmt.Sprintf("watcher auto-skipped after %d consecutive failures. Advancing on runtime verification.", getWatcherFailureCount(state, phase.ID))}
 	} else {
-		continueWatcher, watcherFlow = runCodexContinueWatcherVerification(root, phase, manifest, steps, claims, buildWatcher, workerTimeout)
+		continueWatcher, watcherFlow = runCodexContinueWatcherVerification(ctx, root, phase, manifest, steps, claims, buildWatcher, workerTimeout)
 	}
 	watcher := continueWatcher
 	if !watcher.Present {
@@ -1294,10 +1310,13 @@ func runCodexContinueVerification(root string, state colony.ColonyState, phase c
 	}, watcherFlow
 }
 
-func runCodexContinueWatcherVerification(root string, phase colony.Phase, manifest codexContinueManifest, steps []codexVerificationStep, claims codexClaimVerification, buildWatcher codexWatcherVerification, workerTimeout time.Duration) (codexWatcherVerification, *codexContinueWorkerFlowStep) {
+func runCodexContinueWatcherVerification(ctx context.Context, root string, phase colony.Phase, manifest codexContinueManifest, steps []codexVerificationStep, claims codexClaimVerification, buildWatcher codexWatcherVerification, workerTimeout time.Duration) (codexWatcherVerification, *codexContinueWorkerFlowStep) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	invoker := newCodexWorkerInvoker()
 	dispatch := plannedContinueWatcherDispatch(root, phase, manifest, steps, claims, buildWatcher, invoker, workerTimeout)
-	if !invoker.IsAvailable(context.Background()) {
+	if !invoker.IsAvailable(ctx) {
 		summary := fmt.Sprintf("continue watcher verification could not start because %s", dispatchAvailabilityMessage(invoker))
 		return codexWatcherVerification{
 				Present: true,
@@ -1316,7 +1335,7 @@ func runCodexContinueWatcherVerification(root string, phase colony.Phase, manife
 	}
 
 	spawnTree := agent.NewSpawnTree(store, "spawn-tree.txt")
-	watcherCtx, watcherCancel := context.WithTimeout(context.Background(), effectiveContinueReviewTimeout(workerTimeout))
+	watcherCtx, watcherCancel := context.WithTimeout(ctx, effectiveContinueReviewTimeout(workerTimeout))
 	defer watcherCancel()
 	results, err := dispatchBatchByWaveWithVisuals(
 		watcherCtx,
@@ -2279,7 +2298,7 @@ func setVerificationCommand(commands *codexVerificationCommands, kind, command s
 	}
 }
 
-func runVerificationStep(root, name, command string, timeout time.Duration) codexVerificationStep {
+func runVerificationStep(ctx context.Context, root, name, command string, timeout time.Duration) codexVerificationStep {
 	if strings.TrimSpace(command) == "" {
 		return codexVerificationStep{
 			Name:    name,
@@ -2290,7 +2309,7 @@ func runVerificationStep(root, name, command string, timeout time.Duration) code
 	}
 
 	timeout = effectiveContinueVerificationTimeout(timeout)
-	output, exitCode, timedOut, err := runShellCommand(root, command, timeout)
+	output, exitCode, timedOut, err := runShellCommandContext(ctx, root, command, timeout)
 	step := codexVerificationStep{
 		Name:           name,
 		Command:        command,
@@ -2887,7 +2906,14 @@ func updateCodexContinueContext(phase colony.Phase, manifest codexContinueManife
 }
 
 func runShellCommand(root, command string, timeout time.Duration) (string, int, bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	return runShellCommandContext(context.Background(), root, command, timeout)
+}
+
+func runShellCommandContext(parent context.Context, root, command string, timeout time.Duration) (string, int, bool, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
 
 	var cmd *exec.Cmd

--- a/cmd/codex_continue_finalize.go
+++ b/cmd/codex_continue_finalize.go
@@ -205,7 +205,9 @@ func runCodexContinueFinalize(root string, completion codexExternalContinueCompl
 			Detail:    c.Detail,
 		})
 	}
-	_ = gateResultsWrite(gateResultEntries)
+	if err := gateResultsWrite(gateResultEntries); err != nil {
+		return nil, state, phase, nil, nil, false, fmt.Errorf("failed to persist gate results: %w", err)
+	}
 
 	// Per-phase gate results persistence (D-14)
 	var phaseGateResults []GateCheckResult
@@ -223,7 +225,9 @@ func runCodexContinueFinalize(root string, completion codexExternalContinueCompl
 			Timestamp:       now.Format(time.RFC3339),
 		})
 	}
-	_ = gateResultsWritePhase(phase.ID, phaseGateResults)
+	if err := gateResultsWritePhase(phase.ID, phaseGateResults); err != nil {
+		return nil, state, phase, nil, nil, false, fmt.Errorf("failed to persist phase gate results: %w", err)
+	}
 
 	if err := writeCodexContinueWorkerOutcomeReports(root, phase, workerFlow, now); err != nil {
 		return nil, state, phase, nil, nil, false, err
@@ -268,7 +272,9 @@ func runCodexContinueFinalize(root string, completion codexExternalContinueCompl
 				}
 				phaseGateResults = append(phaseGateResults, entry)
 			}
-			_ = gateResultsWritePhase(phase.ID, phaseGateResults)
+			if err := gateResultsWritePhase(phase.ID, phaseGateResults); err != nil {
+				return nil, state, phase, nil, nil, false, fmt.Errorf("failed to persist auto-resolved phase gate results: %w", err)
+			}
 
 			// Also update COLONY_STATE.json gate results
 			var updatedGateEntries []colony.GateResultEntry
@@ -280,7 +286,9 @@ func runCodexContinueFinalize(root string, completion codexExternalContinueCompl
 					Detail:    c.Detail,
 				})
 			}
-			_ = gateResultsWrite(updatedGateEntries)
+			if err := gateResultsWrite(updatedGateEntries); err != nil {
+				return nil, state, phase, nil, nil, false, fmt.Errorf("failed to persist auto-resolved gate results: %w", err)
+			}
 
 			// Log recovery actions (per RECV-06, using Phase 94 recovery log)
 			var recoveryEntries []RecoveryLogEntry

--- a/cmd/codex_continue_plan.go
+++ b/cmd/codex_continue_plan.go
@@ -1,37 +1,38 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/calcosmic/Aether/pkg/colony"
 	"github.com/calcosmic/Aether/pkg/codex"
+	"github.com/calcosmic/Aether/pkg/colony"
 )
 
 type codexContinueExternalDispatch struct {
-	Stage         string   `json:"stage"`
-	Wave          int      `json:"wave"`
-	Caste         string   `json:"caste"`
-	AgentName     string   `json:"agent_name,omitempty"`
-	Name          string   `json:"name"`
-	Task          string   `json:"task"`
-	TaskID        string   `json:"task_id"`
-	Timeout       int      `json:"timeout_seconds,omitempty"`
-	Status        string   `json:"status"`
-	Summary       string   `json:"summary,omitempty"`
-	Blockers      []string `json:"blockers,omitempty"`
-	Duration      float64  `json:"duration,omitempty"`
-	Report        string   `json:"report,omitempty"`
-	Brief         string   `json:"brief,omitempty"`
-	SkillSection  string   `json:"skill_section,omitempty"`
-	SkillCount    int      `json:"skill_count,omitempty"`
-	ColonySkills  int      `json:"colony_skill_count,omitempty"`
-	DomainSkills  int      `json:"domain_skill_count,omitempty"`
-	MatchedSkills []string `json:"matched_skills,omitempty"`
-	Handoff      codex.WorkerHandoff `json:"handoff,omitempty"`
+	Stage         string              `json:"stage"`
+	Wave          int                 `json:"wave"`
+	Caste         string              `json:"caste"`
+	AgentName     string              `json:"agent_name,omitempty"`
+	Name          string              `json:"name"`
+	Task          string              `json:"task"`
+	TaskID        string              `json:"task_id"`
+	Timeout       int                 `json:"timeout_seconds,omitempty"`
+	Status        string              `json:"status"`
+	Summary       string              `json:"summary,omitempty"`
+	Blockers      []string            `json:"blockers,omitempty"`
+	Duration      float64             `json:"duration,omitempty"`
+	Report        string              `json:"report,omitempty"`
+	Brief         string              `json:"brief,omitempty"`
+	SkillSection  string              `json:"skill_section,omitempty"`
+	SkillCount    int                 `json:"skill_count,omitempty"`
+	ColonySkills  int                 `json:"colony_skill_count,omitempty"`
+	DomainSkills  int                 `json:"domain_skill_count,omitempty"`
+	MatchedSkills []string            `json:"matched_skills,omitempty"`
+	Handoff       codex.WorkerHandoff `json:"handoff,omitempty"`
 }
 
 type codexContinuePlanManifest struct {
@@ -170,10 +171,10 @@ func runCodexContinuePlanOnly(root string, options codexContinueOptions) (map[st
 func runCodexContinueVerificationSnapshot(root string, phase colony.Phase, manifest codexContinueManifest, now time.Time, verificationTimeout time.Duration, skipWatchers bool) codexContinueVerificationReport {
 	commands := resolveCodexVerificationCommands(root)
 	steps := []codexVerificationStep{
-		runVerificationStep(root, "build", commands.Build, verificationTimeout),
-		runVerificationStep(root, "types", commands.Type, verificationTimeout),
-		runVerificationStep(root, "lint", commands.Lint, verificationTimeout),
-		runVerificationStep(root, "tests", commands.Test, verificationTimeout),
+		runVerificationStep(context.Background(), root, "build", commands.Build, verificationTimeout),
+		runVerificationStep(context.Background(), root, "types", commands.Type, verificationTimeout),
+		runVerificationStep(context.Background(), root, "lint", commands.Lint, verificationTimeout),
+		runVerificationStep(context.Background(), root, "tests", commands.Test, verificationTimeout),
 	}
 	claims := verifyCodexBuildClaims(root, manifest)
 	watcher := evaluateContinueWatcherVerification(manifest)

--- a/cmd/codex_continue_test.go
+++ b/cmd/codex_continue_test.go
@@ -3043,7 +3043,7 @@ func TestRunVerificationStepUsesConfigurableTimeout(t *testing.T) {
 		t.Skip("sleep command not available on Windows")
 	}
 
-	step := runVerificationStep(t.TempDir(), "tests", "sleep 5", 100*time.Millisecond)
+	step := runVerificationStep(context.Background(), t.TempDir(), "tests", "sleep 5", 100*time.Millisecond)
 
 	if step.Passed {
 		t.Fatal("verification step passed, want timeout failure")

--- a/cmd/codex_visuals.go
+++ b/cmd/codex_visuals.go
@@ -1098,7 +1098,7 @@ func renderReviewDepthLine(depth colony.VerificationDepth, phaseNum, totalPhases
 	case colony.VerificationDepthStandard:
 		return fmt.Sprintf("Review depth: standard (Phase %d of %d)", phaseNum, totalPhases)
 	default:
-		return fmt.Sprintf("Review depth: light (Phase %d of %d -- final phase gets full review)", phaseNum, totalPhases)
+		return fmt.Sprintf("Review depth: light (Phase %d of %d)", phaseNum, totalPhases)
 	}
 }
 

--- a/cmd/compatibility_cmds.go
+++ b/cmd/compatibility_cmds.go
@@ -23,6 +23,8 @@ type runCompatibilityOptions struct {
 	Headless              bool
 	Verbose               bool
 	WorkerTimeout         time.Duration
+	RunTimeout            time.Duration
+	Context               context.Context
 }
 
 var watchCmd = &cobra.Command{
@@ -89,10 +91,22 @@ var runCompatibilityCmd = &cobra.Command{
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		headless, _ := cmd.Flags().GetBool("headless")
 		verbose, _ := cmd.Flags().GetBool("verbose")
+		runTimeout, _ := cmd.Flags().GetDuration("timeout")
 		workerTimeout, err := resolveWorkerTimeoutFlag(cmd)
 		if err != nil {
 			outputError(1, err.Error(), nil)
 			return nil
+		}
+		parentCtx := cmd.Context()
+		if parentCtx == nil {
+			parentCtx = context.Background()
+		}
+		runCtx, stopSignals := signal.NotifyContext(parentCtx, os.Interrupt, syscall.SIGTERM)
+		defer stopSignals()
+		if runTimeout > 0 {
+			var cancel context.CancelFunc
+			runCtx, cancel = context.WithTimeout(runCtx, runTimeout)
+			defer cancel()
 		}
 
 		result, err := runCompatibilityAutopilot(skillWorkspaceRoot(), runCompatibilityOptions{
@@ -103,6 +117,8 @@ var runCompatibilityCmd = &cobra.Command{
 			Headless:              headless,
 			Verbose:               verbose,
 			WorkerTimeout:         workerTimeout,
+			RunTimeout:            runTimeout,
+			Context:               runCtx,
 		})
 		if err != nil {
 			outputError(1, err.Error(), nil)
@@ -136,6 +152,7 @@ func init() {
 	runCompatibilityCmd.Flags().Bool("headless", false, "Record headless mode in autopilot state")
 	runCompatibilityCmd.Flags().BoolP("verbose", "v", false, "Include extra execution detail in the result")
 	runCompatibilityCmd.Flags().Duration("worker-timeout", 0, "Override per-worker timeout for build and continue dispatches (e.g. 15m)")
+	runCompatibilityCmd.Flags().Duration("timeout", 0, "Optional overall autopilot deadline; normal runs are bounded by phase and worker timeouts")
 
 	oracleCmd.Flags().String("depth", "", "Research depth: quick, balanced, deep, exhaustive (default: balanced)")
 	oracleCmd.Flags().String("confidence-target", "", "Target confidence percentage 1-100 (default: per depth level). Oracle will not finalize below this target unless a hard blocker is reported or max iterations are reached.")
@@ -201,6 +218,11 @@ func runLiveWatch(interval time.Duration) error {
 }
 
 func runCompatibilityAutopilot(root string, opts runCompatibilityOptions) (map[string]interface{}, error) {
+	ctx := opts.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	state, err := loadCompatibilityColonyState()
 	if err != nil {
 		return nil, err
@@ -217,6 +239,19 @@ func runCompatibilityAutopilot(root string, opts runCompatibilityOptions) (map[s
 	phasesCompleted := 0
 
 	for {
+		if err := ctx.Err(); err != nil {
+			_ = syncRunAutopilotState(state, opts, "paused")
+			reason := "cancelled"
+			if err == context.DeadlineExceeded {
+				reason = "timeout"
+			}
+			result := buildRunExecutionResult(state, opts, steps, phasesCompleted, reason, nextCommandFromState(state))
+			result["error"] = err.Error()
+			if opts.RunTimeout > 0 {
+				result["run_timeout_sec"] = int(opts.RunTimeout / time.Second)
+			}
+			return result, nil
+		}
 		if err := syncRunAutopilotState(state, opts, "running"); err != nil {
 			return nil, err
 		}
@@ -240,12 +275,21 @@ func runCompatibilityAutopilot(root string, opts runCompatibilityOptions) (map[s
 
 			buildResult, err := runCodexBuildWithOptions(root, phase.ID, nil, false, codexBuildOptions{
 				WorkerTimeout: opts.WorkerTimeout,
+				ParentContext: ctx,
 			})
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "⚠ Build failed for phase %d, attempting single retry...\n", phase.ID)
-				time.Sleep(2 * time.Second)
+				select {
+				case <-ctx.Done():
+					_ = syncRunAutopilotState(state, opts, "paused")
+					result := buildRunExecutionResult(state, opts, steps, phasesCompleted, "cancelled", nextCommandFromState(state))
+					result["error"] = ctx.Err().Error()
+					return result, nil
+				case <-time.After(2 * time.Second):
+				}
 				buildResult, err = runCodexBuildWithOptions(root, phase.ID, nil, false, codexBuildOptions{
 					WorkerTimeout: opts.WorkerTimeout,
+					ParentContext: ctx,
 				})
 				if err != nil {
 					_ = syncRunAutopilotState(state, opts, "paused")
@@ -270,6 +314,7 @@ func runCompatibilityAutopilot(root string, opts runCompatibilityOptions) (map[s
 		case colony.StateEXECUTING, colony.StateBUILT:
 			continueResult, updatedState, phase, _, _, final, err := runCodexContinue(root, codexContinueOptions{
 				WorkerTimeout: opts.WorkerTimeout,
+				ParentContext: ctx,
 			})
 			if err != nil {
 				_ = syncRunAutopilotState(state, opts, "paused")

--- a/cmd/compatibility_cmds_test.go
+++ b/cmd/compatibility_cmds_test.go
@@ -746,6 +746,95 @@ func TestOracleCompatibilityPersistsWorkerErrorReason(t *testing.T) {
 	}
 }
 
+func TestOracleCompatibilityAcceptsResponseFileDespiteWorkerClaimsParseError(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+
+	dataDir := setupBuildFlowTest(t)
+	root := filepath.Dir(filepath.Dir(dataDir))
+	withWorkingDir(t, root)
+
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/oracle-response-parse-test\n\ngo 1.24\n"), 0644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	agentsDir := filepath.Join(root, ".codex", "agents")
+	if err := os.MkdirAll(agentsDir, 0755); err != nil {
+		t.Fatalf("mkdir agents: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentsDir, "aether-oracle.toml"), validCodexAgentTOML("aether-oracle", "oracle"), 0644); err != nil {
+		t.Fatalf("write oracle agent: %v", err)
+	}
+
+	invoker := &oracleResponseWithClaimsParseErrorInvoker{}
+	originalInvoker := newOracleWorkerInvoker
+	newOracleWorkerInvoker = func() codex.WorkerInvoker { return invoker }
+	defer func() { newOracleWorkerInvoker = originalInvoker }()
+
+	rootCmd.SetArgs([]string{"oracle", "--depth", "exhaustive", "response file parse recovery"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("oracle start returned error: %v", err)
+	}
+
+	env := parseEnvelope(t, stdout.(*bytes.Buffer).String())
+	result := env["result"].(map[string]interface{})
+	if result["status"] != "complete" {
+		t.Fatalf("status = %v, want complete", result["status"])
+	}
+	if invoker.calls == 0 {
+		t.Fatal("expected oracle worker to be invoked")
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".aether", "oracle", "discoveries", "iteration-01.json"))
+	if err != nil {
+		t.Fatalf("read discovery artifact: %v", err)
+	}
+	if strings.Contains(string(data), "parse worker output") {
+		t.Fatalf("valid response file should suppress final claims parse error, got:\n%s", string(data))
+	}
+}
+
+func TestOracleCompatibilityRecoversResponseFromMalformedFinalMessage(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+
+	dataDir := setupBuildFlowTest(t)
+	root := filepath.Dir(filepath.Dir(dataDir))
+	withWorkingDir(t, root)
+
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/oracle-final-payload-test\n\ngo 1.24\n"), 0644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	agentsDir := filepath.Join(root, ".codex", "agents")
+	if err := os.MkdirAll(agentsDir, 0755); err != nil {
+		t.Fatalf("mkdir agents: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentsDir, "aether-oracle.toml"), validCodexAgentTOML("aether-oracle", "oracle"), 0644); err != nil {
+		t.Fatalf("write oracle agent: %v", err)
+	}
+
+	invoker := &oracleFinalPayloadParseErrorInvoker{}
+	originalInvoker := newOracleWorkerInvoker
+	newOracleWorkerInvoker = func() codex.WorkerInvoker { return invoker }
+	defer func() { newOracleWorkerInvoker = originalInvoker }()
+
+	rootCmd.SetArgs([]string{"oracle", "--depth", "exhaustive", "final payload parse recovery"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("oracle start returned error: %v", err)
+	}
+
+	env := parseEnvelope(t, stdout.(*bytes.Buffer).String())
+	result := env["result"].(map[string]interface{})
+	if result["status"] != "complete" {
+		t.Fatalf("status = %v, want complete", result["status"])
+	}
+	matches, err := filepath.Glob(filepath.Join(root, ".aether", "oracle", "responses", "iteration-01-attempt-*.json"))
+	if err != nil {
+		t.Fatalf("glob response files: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("expected recovered final payload to be persisted to the response file")
+	}
+}
+
 func TestOracleCompatibilityRetriesRecoverableWorkerFailure(t *testing.T) {
 	saveGlobals(t)
 	resetRootCmd(t)
@@ -1072,6 +1161,82 @@ func (i *oracleErrorInvoker) Invoke(ctx context.Context, cfg codex.WorkerConfig)
 
 func (i *oracleErrorInvoker) IsAvailable(ctx context.Context) bool { return true }
 func (i *oracleErrorInvoker) ValidateAgent(path string) error      { return nil }
+
+type oracleResponseWithClaimsParseErrorInvoker struct {
+	calls int
+}
+
+func (i *oracleResponseWithClaimsParseErrorInvoker) Invoke(ctx context.Context, cfg codex.WorkerConfig) (codex.WorkerResult, error) {
+	i.calls++
+	if err := writeOracleTestResponse(cfg, oracleWorkerResponse{
+		QuestionID: oracleTestActiveQuestionID(cfg.Root),
+		Status:     "answered",
+		Confidence: 99,
+		Summary:    "Oracle response file survived a malformed final worker claims message.",
+		Findings: []oracleWorkerFinding{{
+			Text: "The Oracle response file is authoritative even when final worker claims cannot be parsed.",
+			Evidence: []oracleWorkerEvidence{{
+				Title:    "Oracle parse recovery test",
+				Location: "cmd/oracle_loop.go",
+				Type:     "codebase",
+			}},
+		}},
+	}); err != nil {
+		return codex.WorkerResult{}, err
+	}
+	return codex.WorkerResult{
+		WorkerName: cfg.WorkerName,
+		Caste:      cfg.Caste,
+		TaskID:     cfg.TaskID,
+		Status:     "failed",
+		RawOutput:  "worker emitted malformed final claims after writing a valid Oracle response",
+		Error:      fmt.Errorf("parse worker output: invalid JSON"),
+	}, nil
+}
+
+func (i *oracleResponseWithClaimsParseErrorInvoker) IsAvailable(ctx context.Context) bool {
+	return true
+}
+func (i *oracleResponseWithClaimsParseErrorInvoker) ValidateAgent(path string) error { return nil }
+
+type oracleFinalPayloadParseErrorInvoker struct {
+	calls int
+}
+
+func (i *oracleFinalPayloadParseErrorInvoker) Invoke(ctx context.Context, cfg codex.WorkerConfig) (codex.WorkerResult, error) {
+	i.calls++
+	response := oracleWorkerResponse{
+		QuestionID: oracleTestActiveQuestionID(cfg.Root),
+		Status:     "answered",
+		Confidence: 99,
+		Summary:    "Oracle payload was recovered from the malformed final message path.",
+		Findings: []oracleWorkerFinding{{
+			Text: "The Oracle controller can recover a valid response object from worker output.",
+			Evidence: []oracleWorkerEvidence{{
+				Title:    "Oracle final payload recovery test",
+				Location: "cmd/oracle_loop.go",
+				Type:     "codebase",
+			}},
+		}},
+	}
+	data, err := json.Marshal(response)
+	if err != nil {
+		return codex.WorkerResult{}, err
+	}
+	return codex.WorkerResult{
+		WorkerName: cfg.WorkerName,
+		Caste:      cfg.Caste,
+		TaskID:     cfg.TaskID,
+		Status:     "failed",
+		RawOutput:  "```json\n" + string(data) + "\n```",
+		Error:      fmt.Errorf("parse worker output: invalid JSON"),
+	}, nil
+}
+
+func (i *oracleFinalPayloadParseErrorInvoker) IsAvailable(ctx context.Context) bool {
+	return true
+}
+func (i *oracleFinalPayloadParseErrorInvoker) ValidateAgent(path string) error { return nil }
 
 type oracleCapturingInvoker struct {
 	configs []codex.WorkerConfig

--- a/cmd/continue_wrapper_ceremony_test.go
+++ b/cmd/continue_wrapper_ceremony_test.go
@@ -157,6 +157,7 @@ func TestContinueWrapperSourcesUseFastDevContinue(t *testing.T) {
 	command := "AETHER_OUTPUT_MODE=visual aether continue --skip-watchers --verification-depth standard $ARGUMENTS"
 	paths := []string{
 		filepath.Join(repoRoot, ".aether", "commands", "continue.yaml"),
+		filepath.Join(repoRoot, ".claude", "commands", "ant-continue.md"),
 		filepath.Join(repoRoot, ".claude", "commands", "ant", "continue.md"),
 		filepath.Join(repoRoot, ".opencode", "commands", "ant", "continue.md"),
 	}

--- a/cmd/gate.go
+++ b/cmd/gate.go
@@ -194,9 +194,20 @@ func checkTestsPass() gateCheck {
 		}
 	}
 
-	cmd := exec.Command(parts[0], parts[1:]...)
+	ctx, cancel := context.WithTimeout(context.Background(), BuildTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
 	cmd.Dir = storage.ResolveAetherRoot(context.Background())
 	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return gateCheck{
+			Name:    "tests_pass",
+			Passed:  false,
+			Detail:  fmt.Sprintf("test command timed out after %s", BuildTimeout),
+			FixHint: "rerun the test command with a longer targeted timeout or investigate the hanging test",
+		}
+	}
 
 	if err != nil {
 		// Test command failed — extract summary from output
@@ -749,7 +760,7 @@ func autoResolveSoftBlockGates(phaseNum int, gates codexContinueGateReport, revi
 			continue
 		}
 
-			threshold, ok := thresholds[check.Name]
+		threshold, ok := thresholds[check.Name]
 		if !ok {
 			// Unclassified soft_block gate (should not happen, but safe default)
 			remainingBlockers = append(remainingBlockers, check.Detail)

--- a/cmd/medic_repair.go
+++ b/cmd/medic_repair.go
@@ -85,10 +85,10 @@ func createBackup(dataPath string) (string, error) {
 
 	// Write a manifest so we know what was backed up
 	manifest := map[string]interface{}{
-		"timestamp":     timestamp,
-		"files_copied":  copied,
-		"created_at":    time.Now().UTC().Format(time.RFC3339),
-		"source_path":   dataPath,
+		"timestamp":    timestamp,
+		"files_copied": copied,
+		"created_at":   time.Now().UTC().Format(time.RFC3339),
+		"source_path":  dataPath,
 	}
 	manifestData, _ := json.MarshalIndent(manifest, "", "  ")
 	manifestData = append(manifestData, '\n')
@@ -333,6 +333,17 @@ func repairStateIssues(issue HealthIssue, opts MedicOptions, dataPath string) Re
 		state.State = colony.StateREADY
 		record.After = string(state.State)
 		record.Success = true
+
+	case strings.Contains(issue.Message, "Invalid state"):
+		record.Action = "normalize_invalid_state"
+		record.Before = string(state.State)
+		state = normalizeLegacyColonyState(state)
+		record.After = string(state.State)
+		record.Success = isValidColonyLifecycleState(state.State)
+		if !record.Success {
+			record.Error = fmt.Sprintf("normalized state is still invalid: %q", state.State)
+			return record
+		}
 
 	default:
 		if strings.Contains(strings.ToLower(issue.Message), "deprecated") {

--- a/cmd/medic_repair_test.go
+++ b/cmd/medic_repair_test.go
@@ -73,7 +73,7 @@ func TestCleanupOldBackups(t *testing.T) {
 
 	// Create 5 backup directories
 	for i := 0; i < 5; i++ {
-		timestamp := time.Now().AddDate(0, 0, -(4-i)).UTC().Format("20060102-150405")
+		timestamp := time.Now().AddDate(0, 0, -(4 - i)).UTC().Format("20060102-150405")
 		path := filepath.Join(backupsDir, "medic-"+timestamp)
 		if err := os.MkdirAll(path, 0755); err != nil {
 			t.Fatalf("create backup %d: %v", i, err)
@@ -262,6 +262,55 @@ func TestRepairLegacyState(t *testing.T) {
 	}
 	if !state.Paused {
 		t.Error("expected paused flag to be set")
+	}
+}
+
+func TestRepairInvalidStateNormalizesRuntimeDrift(t *testing.T) {
+	dir := t.TempDir()
+	dataDir := filepath.Join(dir, ".aether", "data")
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	goal := "Repair invalid production state"
+	writeJSONFile(t, dataDir, "COLONY_STATE.json", map[string]interface{}{
+		"version":       "3.0",
+		"goal":          goal,
+		"state":         "done",
+		"current_phase": 1,
+		"plan": map[string]interface{}{
+			"phases": []interface{}{
+				map[string]interface{}{"id": 1, "name": "Complete", "status": "completed"},
+			},
+		},
+	})
+
+	issue := HealthIssue{
+		Severity: "critical",
+		Category: "state",
+		File:     "COLONY_STATE.json",
+		Message:  "Invalid state 'done'",
+		Fixable:  true,
+	}
+
+	record := repairStateIssues(issue, MedicOptions{Fix: true}, dataDir)
+	if !record.Success {
+		t.Fatalf("repair failed: %s", record.Error)
+	}
+	if record.Action != "normalize_invalid_state" {
+		t.Errorf("action = %q, want %q", record.Action, "normalize_invalid_state")
+	}
+
+	data, err := os.ReadFile(filepath.Join(dataDir, "COLONY_STATE.json"))
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	var state colony.ColonyState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("parse state: %v", err)
+	}
+	if state.State != colony.StateCOMPLETED {
+		t.Fatalf("state = %q, want COMPLETED", state.State)
 	}
 }
 

--- a/cmd/medic_scanner.go
+++ b/cmd/medic_scanner.go
@@ -237,14 +237,9 @@ func scanColonyState(fc *fileChecker) []HealthIssue {
 			"Colony goal is missing"))
 	}
 
-	validStates := map[colony.State]bool{
-		colony.StateIDLE: true, colony.StateREADY: true,
-		colony.StateEXECUTING: true, colony.StateBUILT: true,
-		colony.StateCOMPLETED: true,
-	}
-	if !validStates[state.State] {
-		issues = append(issues, issueCritical("state", filename,
-			fmt.Sprintf("Invalid state '%s'", state.State)))
+	if !isValidColonyLifecycleState(state.State) {
+		issues = append(issues, fixableIssue(issueCritical("state", filename,
+			fmt.Sprintf("Invalid state '%s'", state.State))))
 	}
 
 	if !state.Scope.Valid() && state.Scope != "" {

--- a/cmd/medic_scanner_test.go
+++ b/cmd/medic_scanner_test.go
@@ -149,6 +149,9 @@ func TestScanColonyStateInvalidState(t *testing.T) {
 	for _, issue := range issues {
 		if issue.Severity == "critical" && issue.Category == "state" {
 			found = true
+			if !issue.Fixable {
+				t.Error("invalid state issue should be fixable")
+			}
 		}
 	}
 	if !found {

--- a/cmd/oracle_loop.go
+++ b/cmd/oracle_loop.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/calcosmic/Aether/pkg/codex"
@@ -578,7 +580,9 @@ func startOracleCompatibility(root, topic, depth string, confidenceTarget string
 }
 
 func runOracleLoop(paths oraclePaths, detectedType string, languages, frameworks []string) (map[string]interface{}, error) {
-	ctx := context.Background()
+	ctx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+
 	invoker := newOracleWorkerInvoker()
 	if invoker == nil {
 		invoker = &codex.FakeInvoker{}
@@ -602,6 +606,9 @@ func runOracleLoop(paths oraclePaths, detectedType string, languages, frameworks
 
 	iterationsRun := 0
 	for state.Iteration < state.MaxIterations {
+		if ctx.Err() != nil {
+			return finalizeOracleLoop(paths, state, plan, detectedType, languages, frameworks, iterationsRun, "stopped", "cancelled", "aether oracle status")
+		}
 		if oracleStopRequested(paths.StopPath) {
 			return finalizeOracleLoop(paths, state, plan, detectedType, languages, frameworks, iterationsRun, "stopped", "manual_stop", "aether oracle status")
 		}
@@ -668,6 +675,9 @@ func runOracleLoop(paths oraclePaths, detectedType string, languages, frameworks
 			}
 
 			result, invokeErr = runOracleIterationAttempt(ctx, invoker, paths, state, plan, detectedType, languages, frameworks, target, attempt, policy, responsePath)
+			if ctx.Err() != nil {
+				return finalizeOracleLoop(paths, state, plan, detectedType, languages, frameworks, iterationsRun, "stopped", "cancelled", "aether oracle status")
+			}
 			replyLoaded = false
 			if invokeErr == nil && result.Error == nil && !strings.EqualFold(strings.TrimSpace(result.Status), "failed") {
 				workerReply, invokeErr = loadOracleWorkerResponse(responsePath, target)
@@ -1080,6 +1090,16 @@ func runOracleIterationAttempt(ctx context.Context, invoker codex.WorkerInvoker,
 		select {
 		case attemptResult := <-resultCh:
 			return attemptResult.result, attemptResult.err
+		case <-ctx.Done():
+			cancel()
+			return codex.WorkerResult{
+				Caste:    "oracle",
+				TaskID:   fmt.Sprintf("oracle.%d", state.Iteration),
+				Status:   "timeout",
+				Summary:  fmt.Sprintf("Oracle attempt stopped: %v", ctx.Err()),
+				Duration: time.Since(startedAt),
+				Error:    ctx.Err(),
+			}, ctx.Err()
 		case <-ticker.C:
 			elapsed := time.Since(startedAt)
 			if response, err := loadOracleWorkerResponse(responsePath, target); err == nil {

--- a/cmd/oracle_loop.go
+++ b/cmd/oracle_loop.go
@@ -679,10 +679,18 @@ func runOracleLoop(paths oraclePaths, detectedType string, languages, frameworks
 				return finalizeOracleLoop(paths, state, plan, detectedType, languages, frameworks, iterationsRun, "stopped", "cancelled", "aether oracle status")
 			}
 			replyLoaded = false
-			if invokeErr == nil && result.Error == nil && !strings.EqualFold(strings.TrimSpace(result.Status), "failed") {
-				workerReply, invokeErr = loadOracleWorkerResponse(responsePath, target)
+			workerReply, responseSource, responseErr := loadOracleWorkerResponseForAttempt(responsePath, result, target)
+			if responseErr == nil {
+				replyLoaded = true
+				invokeErr = nil
+				result.Error = nil
+				if responseSource != "file" {
+					if persistErr := writeOracleWorkerResponseFile(responsePath, workerReply); persistErr != nil {
+						invokeErr = persistErr
+						replyLoaded = false
+					}
+				}
 				if invokeErr == nil {
-					replyLoaded = true
 					if strings.TrimSpace(workerReply.Summary) != "" {
 						result.Summary = workerReply.Summary
 					}
@@ -706,6 +714,8 @@ func runOracleLoop(paths oraclePaths, detectedType string, languages, frameworks
 						}
 					}
 				}
+			} else if invokeErr == nil && result.Error == nil && !strings.EqualFold(strings.TrimSpace(result.Status), "failed") {
+				invokeErr = responseErr
 			}
 			artifactPath, artifactErr = writeOracleIterationArtifact(paths, state, attempt, result, invokeErr, responsePath)
 			state.LastArtifactPath = artifactPath
@@ -1848,6 +1858,111 @@ func loadOracleWorkerResponse(path string, target oracleQuestion) (oracleWorkerR
 		return oracleWorkerResponse{}, fmt.Errorf("parse oracle response: %w", err)
 	}
 	return normalizeOracleWorkerResponse(response, target)
+}
+
+func loadOracleWorkerResponseForAttempt(path string, result codex.WorkerResult, target oracleQuestion) (oracleWorkerResponse, string, error) {
+	if response, err := loadOracleWorkerResponse(path, target); err == nil {
+		return response, "file", nil
+	} else if strings.TrimSpace(result.RawOutput) == "" {
+		return oracleWorkerResponse{}, "", err
+	}
+
+	response, err := parseOracleWorkerResponseFromText(result.RawOutput, target)
+	if err == nil {
+		return response, "worker_output", nil
+	}
+	return oracleWorkerResponse{}, "", err
+}
+
+func parseOracleWorkerResponseFromText(text string, target oracleQuestion) (oracleWorkerResponse, error) {
+	candidates := oracleJSONObjectCandidates(text)
+	var lastErr error
+	for _, candidate := range candidates {
+		var response oracleWorkerResponse
+		if err := json.Unmarshal([]byte(candidate), &response); err != nil {
+			lastErr = err
+			continue
+		}
+		normalized, err := normalizeOracleWorkerResponse(response, target)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return normalized, nil
+	}
+	if lastErr != nil {
+		return oracleWorkerResponse{}, fmt.Errorf("parse oracle response from worker output: %w", lastErr)
+	}
+	return oracleWorkerResponse{}, fmt.Errorf("parse oracle response from worker output: no JSON object found")
+}
+
+func oracleJSONObjectCandidates(text string) []string {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return nil
+	}
+	candidates := []string{trimmed}
+	seen := map[string]bool{trimmed: true}
+
+	for start := len(trimmed) - 1; start >= 0; start-- {
+		if trimmed[start] != '{' {
+			continue
+		}
+		depth := 0
+		inString := false
+		escaped := false
+		for end := start; end < len(trimmed); end++ {
+			ch := trimmed[end]
+			if inString {
+				if escaped {
+					escaped = false
+					continue
+				}
+				if ch == '\\' {
+					escaped = true
+					continue
+				}
+				if ch == '"' {
+					inString = false
+				}
+				continue
+			}
+			switch ch {
+			case '"':
+				inString = true
+			case '{':
+				depth++
+			case '}':
+				depth--
+				if depth == 0 {
+					candidate := strings.TrimSpace(trimmed[start : end+1])
+					if candidate != "" && !seen[candidate] {
+						candidates = append(candidates, candidate)
+						seen[candidate] = true
+					}
+					end = len(trimmed)
+				}
+			}
+		}
+	}
+	return candidates
+}
+
+func writeOracleWorkerResponseFile(path string, response oracleWorkerResponse) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("write oracle response: missing response path")
+	}
+	data, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal oracle response: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create oracle response dir: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+		return fmt.Errorf("write oracle response: %w", err)
+	}
+	return nil
 }
 
 func normalizeOracleWorkerResponse(response oracleWorkerResponse, target oracleQuestion) (oracleWorkerResponse, error) {

--- a/cmd/review_depth.go
+++ b/cmd/review_depth.go
@@ -22,19 +22,23 @@ var heavyKeywords = []string{
 }
 
 // resolveReviewDepth determines whether a phase gets light or heavy review.
-// Priority: final phase > heavy flag > keyword match > light/default.
+// Priority: explicit heavy flag > explicit light flag > final phase > keyword match > default.
 func resolveReviewDepth(phase colony.Phase, totalPhases int, lightFlag, heavyFlag bool) ReviewDepth {
-	// Final phase is always heavy regardless of flags.
-	if phase.ID == totalPhases {
-		return ReviewDepthHeavy
-	}
 	// Explicit heavy flag overrides everything else.
 	if heavyFlag {
 		return ReviewDepthHeavy
 	}
+	// Explicit light flag honors the user's request, including on final phases.
+	if lightFlag {
+		return ReviewDepthLight
+	}
+	// Final phase defaults to heavy when the user did not ask for a lighter pass.
+	if phase.ID == totalPhases {
+		return ReviewDepthHeavy
+	}
 	// Keyword auto-detection triggers heavy review, BUT explicit light flag
 	// overrides keyword match (user intent takes priority).
-	if phaseHasHeavyKeywords(phase.Name) && !lightFlag {
+	if phaseHasHeavyKeywords(phase.Name) {
 		return ReviewDepthHeavy
 	}
 	// Default to light for intermediate phases.
@@ -60,28 +64,23 @@ func chaosShouldRunInLightMode(phaseID int) bool {
 }
 
 // resolveVerificationDepth determines the 3-level verification depth for a phase.
-// Priority: final phase -> heavyFlag -> heavy keyword match (unless lightFlag) -> lightFlag -> explicit --verification-depth string -> default standard.
+// Priority: explicit heavy flag -> explicit light flag -> explicit --verification-depth string -> keyword match -> smart default.
 func resolveVerificationDepth(phase colony.Phase, totalPhases int, lightFlag, heavyFlag bool, verificationDepthStr string) colony.VerificationDepth {
-	// Final phase is always heavy regardless of flags.
-	if phase.ID == totalPhases {
-		return colony.VerificationDepthHeavy
-	}
 	// Explicit heavy flag overrides everything else.
 	if heavyFlag {
 		return colony.VerificationDepthHeavy
 	}
-	// Keyword auto-detection triggers heavy review, BUT explicit light flag
-	// overrides keyword match (user intent takes priority).
-	if phaseHasHeavyKeywords(phase.Name) && !lightFlag {
-		return colony.VerificationDepthHeavy
-	}
-	// Explicit light flag.
+	// Explicit light honors the user's request, including on final phases.
 	if lightFlag {
 		return colony.VerificationDepthLight
 	}
-	// Explicit --verification-depth string (normalized).
+	// Explicit --verification-depth string overrides smart defaults.
 	if verificationDepthStr != "" {
 		return colony.NormalizeVerificationDepth(verificationDepthStr)
+	}
+	// Keyword auto-detection triggers heavy review only when depth is automatic.
+	if phaseHasHeavyKeywords(phase.Name) {
+		return colony.VerificationDepthHeavy
 	}
 	// Smart default based on phase position + code change risk.
 	return resolveSmartVerificationDepth(phase, totalPhases)

--- a/cmd/review_depth_test.go
+++ b/cmd/review_depth_test.go
@@ -10,12 +10,11 @@ import (
 	"github.com/calcosmic/Aether/pkg/colony"
 )
 
-func TestResolveReviewDepth_FinalPhaseAlwaysHeavy(t *testing.T) {
+func TestResolveReviewDepth_LightFlagOverridesFinalPhase(t *testing.T) {
 	phase := colony.Phase{ID: 5, Name: "Final polish"}
-	// Final phase (ID == totalPhases) must be heavy even with lightFlag=true
 	got := resolveReviewDepth(phase, 5, true, false)
-	if got != ReviewDepthHeavy {
-		t.Errorf("final phase with lightFlag=true: got %q, want %q", got, ReviewDepthHeavy)
+	if got != ReviewDepthLight {
+		t.Errorf("final phase with lightFlag=true: got %q, want %q", got, ReviewDepthLight)
 	}
 }
 
@@ -69,21 +68,21 @@ func TestResolveReviewDepth_KeywordPhaseAutoHeavy(t *testing.T) {
 		expected ReviewDepth
 	}{
 		{
-			name:     "security keyword triggers heavy",
-			phase:    colony.Phase{ID: 2, Name: "Security audit"},
-			total:    5, light: false, heavy: false,
+			name:  "security keyword triggers heavy",
+			phase: colony.Phase{ID: 2, Name: "Security audit"},
+			total: 5, light: false, heavy: false,
 			expected: ReviewDepthHeavy,
 		},
 		{
-			name:     "keyword phase with light flag overrides to light",
-			phase:    colony.Phase{ID: 2, Name: "Auth refactor"},
-			total:    5, light: true, heavy: false,
+			name:  "keyword phase with light flag overrides to light",
+			phase: colony.Phase{ID: 2, Name: "Auth refactor"},
+			total: 5, light: true, heavy: false,
 			expected: ReviewDepthLight,
 		},
 		{
-			name:     "non-keyword non-final defaults light",
-			phase:    colony.Phase{ID: 2, Name: "UI polish"},
-			total:    5, light: false, heavy: false,
+			name:  "non-keyword non-final defaults light",
+			phase: colony.Phase{ID: 2, Name: "UI polish"},
+			total: 5, light: false, heavy: false,
 			expected: ReviewDepthLight,
 		},
 	}
@@ -405,7 +404,7 @@ func TestRenderReviewDepthLine_HeavyNonFinal(t *testing.T) {
 
 func TestRenderReviewDepthLine_Light(t *testing.T) {
 	got := renderReviewDepthLine(colony.VerificationDepthLight, 3, 5)
-	want := "Review depth: light (Phase 3 of 5 -- final phase gets full review)"
+	want := "Review depth: light (Phase 3 of 5)"
 	if got != want {
 		t.Errorf("renderReviewDepthLine(light, 3, 5) = %q, want %q", got, want)
 	}
@@ -413,16 +412,15 @@ func TestRenderReviewDepthLine_Light(t *testing.T) {
 
 // --- Task 1 tests: VerificationDepth 3-level dispatch ---
 
-func TestResolveVerificationDepth_FinalPhaseAlwaysHeavy(t *testing.T) {
+func TestResolveVerificationDepth_FinalPhaseDefaultsHeavyButHonorsLight(t *testing.T) {
 	phase := colony.Phase{ID: 5, Name: "Final polish"}
 	got := resolveVerificationDepth(phase, 5, false, false, "")
 	if got != colony.VerificationDepthHeavy {
 		t.Errorf("final phase no flags: got %q, want %q", got, colony.VerificationDepthHeavy)
 	}
-	// light flag on final phase still gets heavy
 	got = resolveVerificationDepth(phase, 5, true, false, "")
-	if got != colony.VerificationDepthHeavy {
-		t.Errorf("final phase with lightFlag=true: got %q, want %q", got, colony.VerificationDepthHeavy)
+	if got != colony.VerificationDepthLight {
+		t.Errorf("final phase with lightFlag=true: got %q, want %q", got, colony.VerificationDepthLight)
 	}
 }
 
@@ -491,11 +489,11 @@ func TestResolveVerificationDepth_KeywordPhaseAlwaysHeavy(t *testing.T) {
 func TestResolveVerificationDepthFlag_BoolPriority(t *testing.T) {
 	// --light takes priority over --verification-depth string
 	tests := []struct {
-		name       string
-		light      bool
-		heavy      bool
-		depthStr   string
-		want       string
+		name     string
+		light    bool
+		heavy    bool
+		depthStr string
+		want     string
 	}{
 		{"light flag overrides string", true, false, "heavy", "light"},
 		{"heavy flag overrides string", false, true, "light", "heavy"},
@@ -625,7 +623,7 @@ func TestPhasePositionLevel(t *testing.T) {
 		{"late boundary of 8", 6, 8, "late"}, // 6 >= 8*0.75=6.0, 6 != 8
 		{"late of 8", 7, 8, "late"},
 		{"last is final", 8, 8, "final"},
-		{"late of 5", 4, 5, "late"}, // 4 >= 5*0.75=3.75, 4 != 5
+		{"late of 5", 4, 5, "late"},                 // 4 >= 5*0.75=3.75, 4 != 5
 		{"intermediate of 5", 3, 5, "intermediate"}, // 3 > 1.25, 3 < 3.75
 	}
 	for _, tt := range tests {
@@ -641,8 +639,8 @@ func TestPhasePositionLevel(t *testing.T) {
 func TestCollectPhaseText(t *testing.T) {
 	t.Run("full phase with tasks", func(t *testing.T) {
 		phase := colony.Phase{
-			Name:        "Build Auth",
-			Description: "Add auth middleware",
+			Name:            "Build Auth",
+			Description:     "Add auth middleware",
 			SuccessCriteria: []string{"Auth works"},
 			Tasks: []colony.Task{{
 				Goal:            "Implement login",

--- a/cmd/session_flow_cmds.go
+++ b/cmd/session_flow_cmds.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -19,6 +20,7 @@ const sessionStaleThreshold = 24 * time.Hour
 const handoffStateFence = "aether-colony-state"
 
 var handoffPhaseLinePattern = regexp.MustCompile(`(?i)(?:Current:|Phase:)\s*([0-9]+)\s*/\s*([0-9]+)(?:\s*(?:—|-)\s*(.*))?`)
+var resumeNoHandoff bool
 
 // sessionFreshnessResult describes how fresh a session is for resume.
 type sessionFreshnessResult struct {
@@ -190,7 +192,7 @@ var resumeColonyCmd = &cobra.Command{
 		// Verify session freshness
 		freshness := sessionVerifyFresh(store)
 
-		state, recoveredFromHandoff, stateErr := loadResumeState(handoffText)
+		state, recoveredFromHandoff, stateErr := loadResumeState(handoffText, resumeNoHandoff)
 		if stateErr != nil {
 			renderRecoveryMenu("resume", stateErr.Error(), nil)
 			return nil
@@ -315,23 +317,78 @@ var resumeColonyCmd = &cobra.Command{
 	},
 }
 
-func loadResumeState(handoffText string) (colony.ColonyState, bool, error) {
+func loadResumeState(handoffText string, noHandoff bool) (colony.ColonyState, bool, error) {
 	var rawState colony.ColonyState
+	stateLoaded := false
 	if err := store.LoadJSON("COLONY_STATE.json", &rawState); err == nil {
+		stateLoaded = true
 		state := normalizeLegacyColonyState(rawState)
 		if resumeStateIsRunnable(state) {
 			return state, false, nil
 		}
 	}
 
+	if noHandoff {
+		return colony.ColonyState{}, false, fmt.Errorf("COLONY_STATE.json is not runnable and HANDOFF.md fallback is disabled")
+	}
+
 	state, err := restoreStateFromHandoff(handoffText)
 	if err != nil {
 		return colony.ColonyState{}, false, fmt.Errorf("runtime state is broken and could not be restored from handoff: %w", err)
+	}
+	if stateLoaded {
+		warnResumeHandoffFallback(rawState, state)
+		if resumeHandoffGoalMismatch(rawState, state) {
+			return colony.ColonyState{}, false, fmt.Errorf("HANDOFF.md appears to belong to a different colony; current COLONY_STATE.json goal %q does not match handoff goal %q", colonyStateGoalText(rawState), colonyStateGoalText(state))
+		}
 	}
 	if err := store.SaveJSON("COLONY_STATE.json", state); err != nil {
 		return colony.ColonyState{}, false, fmt.Errorf("failed to restore COLONY_STATE.json from handoff: %w", err)
 	}
 	return state, true, nil
+}
+
+func warnResumeHandoffFallback(currentState, handoffState colony.ColonyState) {
+	fmt.Fprintln(stderr, "warning: COLONY_STATE.json is not runnable; attempting to restore from HANDOFF.md")
+
+	currentGoal := colonyStateGoalText(currentState)
+	handoffGoal := colonyStateGoalText(handoffState)
+	if currentGoal != "" && handoffGoal != "" && !goalsMatch(currentGoal, handoffGoal) {
+		fmt.Fprintf(stderr, "warning: HANDOFF.md goal %q does not match current COLONY_STATE.json goal %q\n", handoffGoal, currentGoal)
+	}
+
+	warnIfHandoffOlderThanCurrentState()
+}
+
+func resumeHandoffGoalMismatch(currentState, handoffState colony.ColonyState) bool {
+	currentGoal := colonyStateGoalText(currentState)
+	handoffGoal := colonyStateGoalText(handoffState)
+	return currentGoal != "" && handoffGoal != "" && !goalsMatch(currentGoal, handoffGoal)
+}
+
+func warnIfHandoffOlderThanCurrentState() {
+	if store == nil {
+		return
+	}
+	stateInfo, stateErr := os.Stat(filepath.Join(store.BasePath(), "COLONY_STATE.json"))
+	handoffInfo, handoffErr := os.Stat(handoffDocumentPath())
+	if stateErr != nil || handoffErr != nil {
+		return
+	}
+	if handoffInfo.ModTime().Before(stateInfo.ModTime()) {
+		fmt.Fprintf(stderr, "warning: HANDOFF.md is older than COLONY_STATE.json; verify the recovered colony before continuing\n")
+	}
+}
+
+func colonyStateGoalText(state colony.ColonyState) string {
+	if state.Goal == nil {
+		return ""
+	}
+	return strings.TrimSpace(*state.Goal)
+}
+
+func goalsMatch(a, b string) bool {
+	return strings.EqualFold(strings.TrimSpace(a), strings.TrimSpace(b))
 }
 
 func resumeStateIsRunnable(state colony.ColonyState) bool {
@@ -648,6 +705,7 @@ func loadOrCreateSessionSummary(now time.Time, state colony.ColonyState) (colony
 }
 
 func init() {
+	resumeColonyCmd.Flags().BoolVar(&resumeNoHandoff, "no-handoff", false, "disable HANDOFF.md fallback when COLONY_STATE.json is not runnable")
 	rootCmd.AddCommand(pauseColonyCmd)
 	rootCmd.AddCommand(resumeColonyCmd)
 }

--- a/cmd/session_flow_cmds_test.go
+++ b/cmd/session_flow_cmds_test.go
@@ -323,6 +323,135 @@ func TestResumeColonyRestoresInvalidStateFromLegacyHandoff(t *testing.T) {
 	}
 }
 
+func TestResumeColonyNoHandoffRejectsBrokenState(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+
+	dataDir := setupBuildFlowTest(t)
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+	stdout = &outBuf
+	stderr = &errBuf
+
+	currentGoal := "Current real colony"
+	handoffGoal := "Old handoff colony"
+	handoffState := colony.ColonyState{
+		Version:      "3.0",
+		Goal:         &handoffGoal,
+		State:        colony.StateREADY,
+		CurrentPhase: 1,
+		Plan: colony.Plan{
+			Phases: []colony.Phase{{ID: 1, Name: "Old phase", Status: colony.PhaseReady}},
+		},
+	}
+	if err := writeHandoffDocument(renderHandoffSnapshot(handoffState, colony.SessionFile{
+		SessionID:      "old-handoff",
+		StartedAt:      "2026-04-15T10:00:00Z",
+		ColonyGoal:     handoffGoal,
+		CurrentPhase:   1,
+		SuggestedNext:  "aether build 1",
+		ContextCleared: true,
+		Summary:        "Old handoff",
+	}, "Paused Colony", "aether build 1", "Old handoff")); err != nil {
+		t.Fatalf("failed to seed handoff: %v", err)
+	}
+	createTestColonyState(t, dataDir, colony.ColonyState{
+		Version:      "3.0",
+		Goal:         &currentGoal,
+		State:        colony.State("BROKEN_STATE"),
+		CurrentPhase: 2,
+		Plan: colony.Plan{
+			Phases: []colony.Phase{{ID: 1, Name: "Current phase", Status: colony.PhaseReady}},
+		},
+	})
+
+	rootCmd.SetArgs([]string{"resume-colony", "--no-handoff"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("resume-colony returned error: %v", err)
+	}
+
+	var state colony.ColonyState
+	if err := store.LoadJSON("COLONY_STATE.json", &state); err != nil {
+		t.Fatalf("failed to reload state: %v", err)
+	}
+	if state.Goal == nil || *state.Goal != currentGoal {
+		t.Fatalf("state was overwritten from handoff: goal=%v", state.Goal)
+	}
+	if state.State != colony.State("BROKEN_STATE") {
+		t.Fatalf("state changed despite --no-handoff: %q", state.State)
+	}
+	if !strings.Contains(errBuf.String(), "HANDOFF.md fallback is disabled") {
+		t.Fatalf("expected no-handoff recovery message, got:\n%s", errBuf.String())
+	}
+}
+
+func TestResumeColonyWarnsAndBlocksOnHandoffGoalMismatch(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+
+	dataDir := setupBuildFlowTest(t)
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+	stdout = &outBuf
+	stderr = &errBuf
+
+	currentGoal := "Current real colony"
+	handoffGoal := "Old handoff colony"
+	handoffState := colony.ColonyState{
+		Version:      "3.0",
+		Goal:         &handoffGoal,
+		State:        colony.StateREADY,
+		CurrentPhase: 1,
+		Plan: colony.Plan{
+			Phases: []colony.Phase{{ID: 1, Name: "Old phase", Status: colony.PhaseReady}},
+		},
+	}
+	if err := writeHandoffDocument(renderHandoffSnapshot(handoffState, colony.SessionFile{
+		SessionID:      "old-handoff",
+		StartedAt:      "2026-04-15T10:00:00Z",
+		ColonyGoal:     handoffGoal,
+		CurrentPhase:   1,
+		SuggestedNext:  "aether build 1",
+		ContextCleared: true,
+		Summary:        "Old handoff",
+	}, "Paused Colony", "aether build 1", "Old handoff")); err != nil {
+		t.Fatalf("failed to seed handoff: %v", err)
+	}
+	createTestColonyState(t, dataDir, colony.ColonyState{
+		Version:      "3.0",
+		Goal:         &currentGoal,
+		State:        colony.State("BROKEN_STATE"),
+		CurrentPhase: 2,
+		Plan: colony.Plan{
+			Phases: []colony.Phase{{ID: 1, Name: "Current phase", Status: colony.PhaseReady}},
+		},
+	})
+
+	rootCmd.SetArgs([]string{"resume-colony"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("resume-colony returned error: %v", err)
+	}
+
+	errOutput := errBuf.String()
+	if !strings.Contains(errOutput, "COLONY_STATE.json is not runnable") {
+		t.Fatalf("expected broken-state handoff warning, got:\n%s", errOutput)
+	}
+	if !strings.Contains(errOutput, "does not match current COLONY_STATE.json goal") {
+		t.Fatalf("expected goal mismatch warning, got:\n%s", errOutput)
+	}
+	if !strings.Contains(errOutput, "appears to belong to a different colony") {
+		t.Fatalf("expected recovery error to block mismatched handoff, got:\n%s", errOutput)
+	}
+
+	var state colony.ColonyState
+	if err := store.LoadJSON("COLONY_STATE.json", &state); err != nil {
+		t.Fatalf("failed to reload state: %v", err)
+	}
+	if state.Goal == nil || *state.Goal != currentGoal {
+		t.Fatalf("mismatched handoff overwrote current goal: %v", state.Goal)
+	}
+}
+
 func TestResumeColonyRotatesStaleSpawnTreeForPausedColony(t *testing.T) {
 	saveGlobals(t)
 	resetRootCmd(t)

--- a/cmd/state_load.go
+++ b/cmd/state_load.go
@@ -100,7 +100,29 @@ func normalizeLegacyColonyState(state colony.ColonyState) colony.ColonyState {
 	hasGoal := state.Goal != nil && strings.TrimSpace(*state.Goal) != ""
 	hasPlanContext := len(state.Plan.Phases) > 0 || state.CurrentPhase > 0
 
+	if rawState == "" {
+		if hasGoal || hasPlanContext {
+			state.State = colony.StateREADY
+		} else {
+			state.State = colony.StateIDLE
+		}
+		return state
+	}
+
 	switch rawState {
+	case "IDLE":
+		state.State = colony.StateIDLE
+		if hasGoal && hasPlanContext {
+			state.State = colony.StateREADY
+		}
+	case "READY":
+		state.State = colony.StateREADY
+	case "EXECUTING":
+		state.State = colony.StateEXECUTING
+	case "BUILT":
+		state.State = colony.StateBUILT
+	case "COMPLETED":
+		state.State = colony.StateCOMPLETED
 	case "PAUSED":
 		state.State = colony.StateREADY
 		state.Paused = true
@@ -110,13 +132,32 @@ func normalizeLegacyColonyState(state colony.ColonyState) colony.ColonyState {
 		state.State = colony.StateCOMPLETED
 	case "ENTOMBED":
 		state.State = colony.StateIDLE
-	case "IDLE":
-		if hasGoal && hasPlanContext {
+	case "DONE", "COMPLETE", "FINISHED":
+		state.State = colony.StateCOMPLETED
+	case "ACTIVE", "RUNNING":
+		state.State = colony.StateEXECUTING
+	case "BUILD":
+		state.State = colony.StateBUILT
+	}
+
+	if !isValidColonyLifecycleState(state.State) {
+		if hasGoal || hasPlanContext {
 			state.State = colony.StateREADY
+		} else {
+			state.State = colony.StateIDLE
 		}
 	}
 
 	return state
+}
+
+func isValidColonyLifecycleState(state colony.State) bool {
+	switch state {
+	case colony.StateIDLE, colony.StateREADY, colony.StateEXECUTING, colony.StateBUILT, colony.StateCOMPLETED:
+		return true
+	default:
+		return false
+	}
 }
 
 func colonyStateLoadMessage(err error) string {

--- a/cmd/state_load_test.go
+++ b/cmd/state_load_test.go
@@ -69,6 +69,51 @@ func TestLoadActiveColonyStateNormalizesBrokenIdleStateWithGoal(t *testing.T) {
 	}
 }
 
+func TestNormalizeLegacyColonyStateHandlesCommonRuntimeValues(t *testing.T) {
+	goal := "Normalize production state drift"
+	phase := colony.Phase{ID: 1, Name: "Recover", Status: colony.PhaseReady}
+	cases := []struct {
+		name         string
+		rawState     colony.State
+		withGoal     bool
+		withPlan     bool
+		currentPhase int
+		want         colony.State
+	}{
+		{name: "lowercase ready", rawState: colony.State("ready"), withGoal: true, withPlan: true, currentPhase: 1, want: colony.StateREADY},
+		{name: "done", rawState: colony.State("done"), withGoal: true, withPlan: true, currentPhase: 1, want: colony.StateCOMPLETED},
+		{name: "complete", rawState: colony.State("COMPLETE"), withGoal: true, withPlan: true, currentPhase: 1, want: colony.StateCOMPLETED},
+		{name: "finished", rawState: colony.State("finished"), withGoal: true, withPlan: true, currentPhase: 1, want: colony.StateCOMPLETED},
+		{name: "active", rawState: colony.State("active"), withGoal: true, withPlan: true, currentPhase: 1, want: colony.StateEXECUTING},
+		{name: "running", rawState: colony.State("running"), withGoal: true, withPlan: true, currentPhase: 1, want: colony.StateEXECUTING},
+		{name: "build", rawState: colony.State("build"), withGoal: true, withPlan: true, currentPhase: 1, want: colony.StateBUILT},
+		{name: "empty with goal", rawState: colony.State(""), withGoal: true, want: colony.StateREADY},
+		{name: "empty without context", rawState: colony.State(""), want: colony.StateIDLE},
+		{name: "unknown with plan", rawState: colony.State("garbage"), withPlan: true, currentPhase: 1, want: colony.StateREADY},
+		{name: "unknown without context", rawState: colony.State("garbage"), want: colony.StateIDLE},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := colony.ColonyState{
+				Version:      "3.0",
+				State:        tc.rawState,
+				CurrentPhase: tc.currentPhase,
+			}
+			if tc.withGoal {
+				state.Goal = &goal
+			}
+			if tc.withPlan {
+				state.Plan = colony.Plan{Phases: []colony.Phase{phase}}
+			}
+			got := normalizeLegacyColonyState(state)
+			if got.State != tc.want {
+				t.Fatalf("normalized state = %q, want %q", got.State, tc.want)
+			}
+		})
+	}
+}
+
 func TestLoadActiveColonyStateRepairsMissingPlanFromPlanningArtifact(t *testing.T) {
 	saveGlobals(t)
 	resetRootCmd(t)

--- a/cmd/swarm_cmd.go
+++ b/cmd/swarm_cmd.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/calcosmic/Aether/pkg/agent"
@@ -15,7 +17,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultSwarmWorkerTimeout = 6 * time.Minute
+const (
+	defaultSwarmWorkerTimeout = 6 * time.Minute
+	defaultSwarmRunTimeout    = 30 * time.Minute
+)
 
 var newSwarmWorkerInvoker = codex.NewWorkerInvoker
 
@@ -182,36 +187,63 @@ func runSwarmDestroy(root, target string) (map[string]interface{}, error) {
 	if invoker == nil {
 		return nil, fmt.Errorf("swarm worker invoker is not configured")
 	}
-	if !invoker.IsAvailable(context.Background()) {
+	parentCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+	ctx, cancel := context.WithTimeout(parentCtx, defaultSwarmRunTimeout)
+	defer cancel()
+
+	if !invoker.IsAvailable(ctx) {
 		return nil, dispatchUnavailableError(invoker)
 	}
 
 	state, _ := loadColonyState()
-	swarmID := fmt.Sprintf("swarm-%d", time.Now().UTC().Unix())
+	startedAt := time.Now().UTC()
+	runHandle, err := beginRuntimeSpawnRun("swarm", startedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize swarm run: %w", err)
+	}
+	runStatus := "failed"
+	defer func() {
+		finishRuntimeSpawnRun(runHandle, runStatus, time.Now().UTC())
+	}()
+
+	swarmID := fmt.Sprintf("swarm-%d", startedAt.Unix())
 	if err := initializeSwarmRun(swarmID); err != nil {
 		return nil, fmt.Errorf("initialize swarm workspace: %w", err)
 	}
 
 	investigation := buildSwarmInvestigationPlans(root, target)
 	emitVisualProgress(renderSwarmDispatchPreview(swarmID, target, investigation, "Investigation Wave"))
-	investigationRuns, err := executeSwarmWave(context.Background(), root, swarmID, target, investigation, "", invoker)
+	investigationRuns, err := executeSwarmWave(ctx, root, swarmID, target, investigation, "", invoker)
 	if err != nil {
+		if ctx.Err() != nil {
+			runStatus = "timeout"
+			return nil, fmt.Errorf("swarm stopped: %w", ctx.Err())
+		}
 		return nil, err
 	}
 
 	findingSummary := renderSwarmFindingSummary(investigationRuns)
 	builderPlan := buildSwarmBuilderPlan(root, target)
 	emitVisualProgress(renderSwarmDispatchPreview(swarmID, target, []swarmWorkerPlan{builderPlan}, "Fix Wave"))
-	builderRuns, err := executeSwarmWave(context.Background(), root, swarmID, target, []swarmWorkerPlan{builderPlan}, findingSummary, invoker)
+	builderRuns, err := executeSwarmWave(ctx, root, swarmID, target, []swarmWorkerPlan{builderPlan}, findingSummary, invoker)
 	if err != nil {
+		if ctx.Err() != nil {
+			runStatus = "timeout"
+			return nil, fmt.Errorf("swarm stopped: %w", ctx.Err())
+		}
 		return nil, err
 	}
 
 	builderSummary := renderSwarmFindingSummary(builderRuns)
 	watcherPlan := buildSwarmWatcherPlan(root, target)
 	emitVisualProgress(renderSwarmDispatchPreview(swarmID, target, []swarmWorkerPlan{watcherPlan}, "Verification Wave"))
-	watcherRuns, err := executeSwarmWave(context.Background(), root, swarmID, target, []swarmWorkerPlan{watcherPlan}, findingSummary+"\n\n"+builderSummary, invoker)
+	watcherRuns, err := executeSwarmWave(ctx, root, swarmID, target, []swarmWorkerPlan{watcherPlan}, findingSummary+"\n\n"+builderSummary, invoker)
 	if err != nil {
+		if ctx.Err() != nil {
+			runStatus = "timeout"
+			return nil, fmt.Errorf("swarm stopped: %w", ctx.Err())
+		}
 		return nil, err
 	}
 
@@ -219,6 +251,7 @@ func runSwarmDestroy(root, target string) (map[string]interface{}, error) {
 	allRuns = append(allRuns, watcherRuns...)
 
 	status, recommendation, rootCause, solution, blockers := summarizeSwarmOutcome(allRuns)
+	runStatus = summarizeRunStatus(status)
 	filesTouched, testsWritten := collectSwarmTouchedFiles(allRuns)
 	next := swarmNextCommand(state, status)
 
@@ -338,6 +371,9 @@ func executeSwarmWave(ctx context.Context, root, swarmID, target string, plans [
 	spawnTree := agent.NewSpawnTree(store, "spawn-tree.txt")
 	runs := make([]swarmWorkerExecution, 0, len(plans))
 	for _, plan := range plans {
+		if err := ctx.Err(); err != nil {
+			return runs, err
+		}
 		if err := spawnTree.RecordSpawn("Swarm", plan.Caste, plan.Name, plan.Task, plan.Wave); err != nil {
 			return nil, fmt.Errorf("record swarm spawn %s: %w", plan.Name, err)
 		}
@@ -623,7 +659,7 @@ func summarizeSwarmOutcome(runs []swarmWorkerExecution) (status, recommendation,
 			if status != "failed" {
 				status = "blocked"
 			}
-		case "failed":
+		case "failed", "timeout":
 			status = "failed"
 		}
 	}

--- a/cmd/testing_main_test.go
+++ b/cmd/testing_main_test.go
@@ -90,6 +90,7 @@ func saveGlobals(t *testing.T) {
 	origNarratorLookPath := narratorLookPath
 	origNarratorCommandContext := narratorCommandContext
 	origNarratorRuntimePath := narratorRuntimePath
+	origResumeNoHandoff := resumeNoHandoff
 	t.Cleanup(func() {
 		store = origStore
 		stdout = origStdout
@@ -110,6 +111,7 @@ func saveGlobals(t *testing.T) {
 		narratorLookPath = origNarratorLookPath
 		narratorCommandContext = origNarratorCommandContext
 		narratorRuntimePath = origNarratorRuntimePath
+		resumeNoHandoff = origResumeNoHandoff
 	})
 }
 

--- a/pkg/agent/stream_manager.go
+++ b/pkg/agent/stream_manager.go
@@ -12,27 +12,27 @@ import (
 
 // StreamState tracks the current state of a single agent's stream.
 type StreamState struct {
-	AgentName    string
-	Caste        Caste
-	Status       StreamStatus
-	Tokens       []string
-	TokenCount   int
-	StartedAt    time.Time
-	CompletedAt  *time.Time
-	Error        error
-	Result       *llm.StreamResult
-	mu           sync.RWMutex
+	AgentName   string
+	Caste       Caste
+	Status      StreamStatus
+	Tokens      []string
+	TokenCount  int
+	StartedAt   time.Time
+	CompletedAt *time.Time
+	Error       error
+	Result      *llm.StreamResult
+	mu          sync.RWMutex
 }
 
 // StreamStatus represents the lifecycle state of a stream.
 type StreamStatus string
 
 const (
-	StreamStatusPending    StreamStatus = "pending"
-	StreamStatusActive     StreamStatus = "active"
-	StreamStatusCompleted  StreamStatus = "completed"
-	StreamStatusFailed     StreamStatus = "failed"
-	StreamStatusCancelled  StreamStatus = "cancelled"
+	StreamStatusPending   StreamStatus = "pending"
+	StreamStatusActive    StreamStatus = "active"
+	StreamStatusCompleted StreamStatus = "completed"
+	StreamStatusFailed    StreamStatus = "failed"
+	StreamStatusCancelled StreamStatus = "cancelled"
 )
 
 // IsActive returns true if the stream is currently active.
@@ -135,10 +135,10 @@ func (s *StreamState) Duration() time.Duration {
 // StreamManager coordinates multiple concurrent agent streams.
 // It uses the spawn tree to track active agents and maps agent names to their stream states.
 type StreamManager struct {
-	spawnTree   *SpawnTree
-	streams     map[string]*StreamState
-	mu          sync.RWMutex
-	maxStreams  int
+	spawnTree  *SpawnTree
+	streams    map[string]*StreamState
+	mu         sync.RWMutex
+	maxStreams int
 }
 
 // NewStreamManager creates a new StreamManager with the given spawn tree.
@@ -171,11 +171,11 @@ func (sm *StreamManager) RegisterAgent(agent Agent) (*StreamState, error) {
 	}
 
 	state := &StreamState{
-		AgentName:  name,
-		Caste:      agent.Caste(),
-		Status:     StreamStatusPending,
-		Tokens:     make([]string, 0),
-		StartedAt:  time.Now(),
+		AgentName: name,
+		Caste:     agent.Caste(),
+		Status:    StreamStatusPending,
+		Tokens:    make([]string, 0),
+		StartedAt: time.Now(),
 	}
 
 	sm.streams[name] = state
@@ -264,14 +264,65 @@ func (sm *StreamManager) TotalCount() int {
 // WaitForAll blocks until all registered streams are complete.
 // Returns a map of agent names to their final states.
 func (sm *StreamManager) WaitForAll() map[string]*StreamState {
+	result, _ := sm.WaitForAllContext(context.Background())
+	return result
+}
+
+// WaitForAllContext blocks until all registered streams are complete or ctx is cancelled.
+// Returns a map of agent names to their latest states.
+func (sm *StreamManager) WaitForAllContext(ctx context.Context) (map[string]*StreamState, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
 	for {
 		active := sm.ActiveCount()
 		if active == 0 {
 			break
 		}
-		time.Sleep(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return sm.snapshotStates(), ctx.Err()
+		case <-ticker.C:
+		}
 	}
 
+	return sm.snapshotStates(), nil
+}
+
+// WaitForAgent blocks until a specific agent's stream is complete.
+func (sm *StreamManager) WaitForAgent(agentName string) (*StreamState, bool) {
+	state, ok, _ := sm.WaitForAgentContext(context.Background(), agentName)
+	return state, ok
+}
+
+// WaitForAgentContext blocks until a specific agent's stream is complete or ctx is cancelled.
+func (sm *StreamManager) WaitForAgentContext(ctx context.Context, agentName string) (*StreamState, bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		state, ok := sm.GetStream(agentName)
+		if !ok {
+			return nil, false, nil
+		}
+		if state.IsComplete() {
+			return state, true, nil
+		}
+		select {
+		case <-ctx.Done():
+			return state, true, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (sm *StreamManager) snapshotStates() map[string]*StreamState {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 
@@ -280,20 +331,6 @@ func (sm *StreamManager) WaitForAll() map[string]*StreamState {
 		result[name] = state
 	}
 	return result
-}
-
-// WaitForAgent blocks until a specific agent's stream is complete.
-func (sm *StreamManager) WaitForAgent(agentName string) (*StreamState, bool) {
-	for {
-		state, ok := sm.GetStream(agentName)
-		if !ok {
-			return nil, false
-		}
-		if state.IsComplete() {
-			return state, true
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
 }
 
 // agentStreamHandler wraps a StreamState to implement llm.StreamHandler.
@@ -356,6 +393,13 @@ func (sm *StreamManager) ExecuteStreamingWithAgent(ctx context.Context, agent St
 
 	// Execute with streaming
 	go func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				state.SetError(fmt.Errorf("streaming agent panic: %v", recovered))
+				state.SetStatus(StreamStatusFailed)
+			}
+		}()
+
 		err := agent.ExecuteStreaming(ctx, event, handler)
 		if err != nil && state.GetError() == nil {
 			state.SetError(err)
@@ -410,9 +454,9 @@ func (sm *StreamManager) GetStreamSummary() StreamSummary {
 	defer sm.mu.RUnlock()
 
 	summary := StreamSummary{
-		Total:     len(sm.streams),
-		ByStatus:  make(map[StreamStatus]int),
-		ByCaste:   make(map[Caste]int),
+		Total:    len(sm.streams),
+		ByStatus: make(map[StreamStatus]int),
+		ByCaste:  make(map[Caste]int),
 	}
 
 	for _, state := range sm.streams {

--- a/pkg/agent/stream_manager_test.go
+++ b/pkg/agent/stream_manager_test.go
@@ -393,6 +393,34 @@ func TestStreamManagerWaitForAgent(t *testing.T) {
 	}
 }
 
+func TestStreamManagerWaitForAllContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+	store, err := storage.NewStore(dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	spawnTree := NewSpawnTree(store, "")
+	sm := NewStreamManager(spawnTree, 0)
+
+	agent := NewBuilderAgent("builder-1")
+	state, _ := sm.RegisterAgent(agent)
+	state.SetStatus(StreamStatusActive)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	results, err := sm.WaitForAllContext(ctx)
+	if err == nil {
+		t.Fatal("WaitForAllContext returned nil error, want context timeout")
+	}
+	if _, ok := results["builder-1"]; !ok {
+		t.Fatal("WaitForAllContext did not return latest state snapshot")
+	}
+	if got := results["builder-1"].GetStatus(); got != StreamStatusActive {
+		t.Fatalf("snapshot status = %s, want active", got)
+	}
+}
+
 // TestStreamManagerExecuteStreamingWithAgent tests executing with streaming.
 func TestStreamManagerExecuteStreamingWithAgent(t *testing.T) {
 	dir := t.TempDir()
@@ -431,6 +459,37 @@ func TestStreamManagerExecuteStreamingWithAgent(t *testing.T) {
 	// Verify result
 	if finalState.GetResult() == nil {
 		t.Error("Should have a result")
+	}
+}
+
+func TestStreamManagerExecuteStreamingWithAgentRecoversPanic(t *testing.T) {
+	dir := t.TempDir()
+	store, err := storage.NewStore(dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	spawnTree := NewSpawnTree(store, "")
+	sm := NewStreamManager(spawnTree, 0)
+
+	agent := &mockStreamingAgent{name: "panic-builder", caste: CasteBuilder, panicStreaming: true}
+	if _, err := sm.ExecuteStreamingWithAgent(context.Background(), agent, events.Event{Topic: "build.start"}); err != nil {
+		t.Fatalf("ExecuteStreamingWithAgent failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	finalState, ok, err := sm.WaitForAgentContext(ctx, "panic-builder")
+	if err != nil {
+		t.Fatalf("WaitForAgentContext returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("panic-builder stream missing")
+	}
+	if got := finalState.GetStatus(); got != StreamStatusFailed {
+		t.Fatalf("status = %s, want failed", got)
+	}
+	if finalState.GetError() == nil || !strings.Contains(finalState.GetError().Error(), "streaming agent panic") {
+		t.Fatalf("panic error not recorded: %v", finalState.GetError())
 	}
 }
 
@@ -767,9 +826,10 @@ func TestStreamManagerWithDifferentCastes(t *testing.T) {
 
 // mockStreamingAgent is a test agent that implements StreamingAgent.
 type mockStreamingAgent struct {
-	name     string
-	caste    Caste
-	triggers []Trigger
+	name           string
+	caste          Caste
+	triggers       []Trigger
+	panicStreaming bool
 }
 
 func (m *mockStreamingAgent) Name() string {
@@ -789,6 +849,9 @@ func (m *mockStreamingAgent) Execute(ctx context.Context, event events.Event) er
 }
 
 func (m *mockStreamingAgent) ExecuteStreaming(ctx context.Context, event events.Event, handler llm.StreamHandler) error {
+	if m.panicStreaming {
+		panic("synthetic streaming panic")
+	}
 	if handler != nil {
 		handler.OnToken("Token from " + m.name)
 		handler.OnComplete(&llm.StreamResult{

--- a/pkg/codex/platform_dispatch.go
+++ b/pkg/codex/platform_dispatch.go
@@ -1127,6 +1127,9 @@ func classifyHostedExecutionError(label string, err error, stderr string, runnin
 	if prefix == "" {
 		prefix = "worker process"
 	}
+	if strings.EqualFold(prefix, "opencode") && looksLikeOpenCodeLocalServerFailure(detail) {
+		return fmt.Errorf("opencode worker dispatcher unavailable: local OpenCode server rejected the run request; ensure OpenCode is running for `opencode run`, or set AETHER_WORKER_PLATFORM=claude/codex to use another dispatcher: %w (stderr: %s)", err, detail)
+	}
 	if !runningObserved {
 		prefix = "worker startup failed"
 	} else {
@@ -1136,6 +1139,15 @@ func classifyHostedExecutionError(label string, err error, stderr string, runnin
 		return fmt.Errorf("%s: %w (stderr: %s)", prefix, err, detail)
 	}
 	return fmt.Errorf("%s: %w", prefix, err)
+}
+
+func looksLikeOpenCodeLocalServerFailure(stderr string) bool {
+	text := strings.ToLower(strings.TrimSpace(stderr))
+	if text == "" {
+		return false
+	}
+	return strings.Contains(text, "localhost:4000/messages") ||
+		(strings.Contains(text, "/messages") && strings.Contains(text, "404"))
 }
 
 func describeAvailabilitySet(active Platform, statuses []AvailabilityStatus) string {

--- a/pkg/codex/platform_dispatch.go
+++ b/pkg/codex/platform_dispatch.go
@@ -616,6 +616,7 @@ func invokeHostedWorker(ctx context.Context, dispatcher PlatformDispatcher, conf
 	if strings.TrimSpace(config.Root) != "" {
 		cmd.Dir = config.Root
 	}
+	configureWorkerCommand(cmd)
 
 	if agentURL := os.Getenv(envOpenCodeAgentURL); agentURL != "" {
 		cmd.Env = append(os.Environ(), envOpenCodeAgentURL+"="+agentURL)
@@ -637,13 +638,17 @@ func invokeHostedWorker(ctx context.Context, dispatcher PlatformDispatcher, conf
 	defer heartbeat.Stop()
 
 	var waitErr error
+	ctxDone := ctx.Done()
 waitLoop:
 	for {
 		select {
 		case waitErr = <-waitCh:
 			break waitLoop
+		case <-ctxDone:
+			ctxDone = nil
+			running.Pulse("worker cancellation requested")
 		case <-heartbeat.C:
-			running.Report("worker heartbeat observed")
+			running.Pulse("worker heartbeat observed")
 		}
 	}
 

--- a/pkg/codex/platform_dispatch_test.go
+++ b/pkg/codex/platform_dispatch_test.go
@@ -226,6 +226,21 @@ EOF
 	}
 }
 
+func TestClassifyHostedExecutionErrorExplainsOpenCodeLocalServerFailure(t *testing.T) {
+	err := classifyHostedExecutionError("opencode", os.ErrNotExist, "POST http://localhost:4000/messages returned 404", false)
+	text := err.Error()
+	for _, want := range []string{
+		"opencode worker dispatcher unavailable",
+		"local OpenCode server",
+		"AETHER_WORKER_PLATFORM=claude/codex",
+		"localhost:4000/messages",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("classified error missing %q:\n%s", want, text)
+		}
+	}
+}
+
 // createTestMarkdownAgent creates a minimal markdown agent file for testing.
 func createTestMarkdownAgent(t *testing.T, dir, name, description string) string {
 	t.Helper()

--- a/pkg/codex/worker.go
+++ b/pkg/codex/worker.go
@@ -23,6 +23,8 @@ const defaultWorkerTimeout = DefaultWorkerTimeout
 const (
 	defaultWorkerHeartbeatInterval = 2 * time.Second
 	minWorkerHeartbeatInterval     = 250 * time.Millisecond
+	workerCancelKillDelay          = 2 * time.Second
+	workerCommandWaitDelay         = 5 * time.Second
 )
 
 // envRealDispatch is the environment variable that enables real codex CLI invocation.
@@ -420,7 +422,7 @@ func (r *RealInvoker) InvokeWithProgress(ctx context.Context, config WorkerConfi
 		cmd.Dir = config.Root
 	}
 	cmd.Stdin = strings.NewReader(prompt)
-	cmd.SysProcAttr = workerSysProcAttr()
+	configureWorkerCommand(cmd)
 
 	var stdout, stderr bytes.Buffer
 	running := newWorkerRunningSignal(observer)
@@ -464,13 +466,17 @@ func (r *RealInvoker) InvokeWithProgress(ctx context.Context, config WorkerConfi
 	defer heartbeat.Stop()
 
 	var waitErr error
+	ctxDone := ctx.Done()
 waitLoop:
 	for {
 		select {
 		case waitErr = <-waitCh:
 			break waitLoop
+		case <-ctxDone:
+			ctxDone = nil
+			running.Pulse("worker cancellation requested")
 		case <-heartbeat.C:
-			running.Report("worker heartbeat observed")
+			running.Pulse("worker heartbeat observed")
 		}
 	}
 
@@ -961,6 +967,18 @@ func (s *workerRunningSignal) Report(message string) {
 	})
 }
 
+func (s *workerRunningSignal) Pulse(message string) {
+	if s == nil {
+		return
+	}
+	s.seen.Store(true)
+	emitWorkerProgress(s.observer, WorkerProgressEvent{
+		Status:     "running",
+		Message:    strings.TrimSpace(message),
+		OccurredAt: time.Now().UTC(),
+	})
+}
+
 func (s *workerRunningSignal) Observed() bool {
 	if s == nil {
 		return false
@@ -989,6 +1007,29 @@ func emitWorkerProgress(observer WorkerProgressObserver, event WorkerProgressEve
 		event.OccurredAt = time.Now().UTC()
 	}
 	observer(event)
+}
+
+func configureWorkerCommand(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	cmd.SysProcAttr = workerSysProcAttr()
+	cmd.WaitDelay = workerCommandWaitDelay
+	if cmd.SysProcAttr == nil {
+		return
+	}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		pid := cmd.Process.Pid
+		err := terminateWorkerProcess(pid)
+		go func() {
+			time.Sleep(workerCancelKillDelay)
+			_ = killWorkerProcess(pid)
+		}()
+		return err
+	}
 }
 
 func validateWorkerLaunchConfig(config WorkerConfig) error {


### PR DESCRIPTION
## Summary
- Harden worker supervision paths so long-running Aether workers are cancellable, observable, and less likely to leave stuck runtime state.
- Make Oracle response files/payloads authoritative when the final worker-claims message is malformed.
- Honor explicit continue verification depth flags, including `--light` on final phases, instead of forcing heavy review against user intent.
- Recover basename-only worker file claims by resolving tracked and untracked repo files.
- Surface OpenCode localhost `/messages` 404s as platform dispatcher failures with an actionable `AETHER_WORKER_PLATFORM` hint.
- Refresh Claude/OpenCode continue wrapper text so global commands, hub commands, and source wrappers agree.

## Verification
- `go test ./...`
- `go test ./... -race`

## Publish
- Published local stable hub with `AETHER_OUTPUT_MODE=visual aether publish --channel stable --binary-dest "$HOME/.local/bin"`.
- Verified `aether version` returns `1.0.28`.
- Verified local Claude/OpenCode command surfaces now use `aether continue --skip-watchers --verification-depth standard`.