### PR TITLE
Repair platform asset updates and planning contracts

### DIFF
--- a/.aether/.gitignore
+++ b/.aether/.gitignore
@@ -6,7 +6,9 @@ locks/
 agents/
 chambers/
 midden/
-rules/
+rules/*
+!rules/
+!rules/aether-colony.md
 settings/
 archive/
 backups/

--- a/.aether/rules/aether-colony.md
+++ b/.aether/rules/aether-colony.md
@@ -1,0 +1,160 @@
+# Aether Colony System
+
+> This repo uses the Aether colony system for multi-agent development.
+> These rules are auto-distributed by `aether update` — do not edit directly.
+
+## Session Recovery
+
+On the first message of a new conversation, check if `.aether/data/session.json` exists. If it does:
+
+1. Read the file briefly to check for `colony_goal`
+2. If a goal exists, display:
+   ```
+   Previous colony session detected: "{goal}"
+   Run /ant-resume to restore context, or continue with a new topic.
+   ```
+3. Do NOT auto-restore — wait for the user to explicitly run /ant-resume
+
+This only applies to genuinely new conversations, not after /clear.
+
+## Available Commands
+
+### Setup & Getting Started
+| Command | Purpose |
+|---------|---------|
+| `/ant-lay-eggs` | Set up Aether in this repo (one-time, creates .aether/) |
+| `/ant-init "<goal>"` | Start a colony with a goal |
+| `/ant-colonize` | Analyze existing codebase |
+| `/ant-plan` | Generate project phases |
+| `/ant-build <phase>` | Execute a phase with parallel workers |
+| `/ant-continue` | Verify work, extract learnings, advance |
+
+### Pheromone Signals
+| Command | Priority | Purpose |
+|---------|----------|---------|
+| `/ant-focus "<area>"` | normal | Guide colony attention |
+| `/ant-redirect "<pattern>"` | high | Hard constraint — avoid this |
+| `/ant-feedback "<note>"` | low | Gentle adjustment |
+| `/ant-pheromones` | — | View all active signals |
+| `/ant-export-signals` | — | Export signals to XML |
+| `/ant-import-signals` | — | Import signals from XML |
+
+### Status & Monitoring
+| Command | Purpose |
+|---------|---------|
+| `/ant-status` | Colony dashboard |
+| `/ant-phase [N]` | View phase details |
+| `/ant-flags` | List active flags |
+| `/ant-flag "<title>"` | Create a flag |
+| `/ant-history` | Browse colony events |
+| `/ant-watch` | Live tmux monitoring |
+| `/ant-memory-details` | Drill-down memory view |
+| `/ant-patrol` | System health check |
+| `/ant-help` | List available commands |
+
+### Session Management
+| Command | Purpose |
+|---------|---------|
+| `/ant-pause-colony` | Save state and create handoff |
+| `/ant-resume-colony` | Restore from pause |
+| `/ant-resume` | Quick session restore |
+
+### Lifecycle
+| Command | Purpose |
+|---------|---------|
+| `/ant-seal` | Seal colony (Crowned Anthill) |
+| `/ant-entomb` | Archive completed colony |
+| `/ant-maturity` | View colony maturity journey |
+| `/ant-update` | Update system files from hub |
+| `/ant-migrate-state` | Migrate colony state between versions |
+
+### Advanced
+| Command | Purpose |
+|---------|---------|
+| `/ant-run` | Autopilot — build, verify, advance automatically |
+| `/ant-quick` | Quick one-shot task |
+| `/ant-swarm "<bug>"` | Parallel bug investigation |
+| `/ant-oracle` | Deep research (RALF loop) |
+| `/ant-dream` | Philosophical observation |
+| `/ant-interpret` | Review dreams, discuss actions |
+| `/ant-chaos` | Resilience testing |
+| `/ant-archaeology` | Git history analysis |
+| `/ant-organize` | Codebase hygiene report |
+| `/ant-council` | Intent clarification |
+| `/ant-preferences` | Set user preferences |
+| `/ant-skill-create` | Create a custom skill |
+| `/ant-insert-phase` | Insert phase into plan |
+| `/ant-tunnels` | View colony communication tunnels |
+| `/ant-data-clean` | Clean test artifacts from data files |
+| `/ant-verify-castes` | Verify worker caste assignments |
+
+## Typical Workflow
+
+```
+First time in a repo:
+0. /ant-lay-eggs                           (set up Aether in this repo)
+
+Starting a colony:
+1. /ant-init "Build feature X"             (start colony with a goal)
+2. /ant-colonize                           (if existing code)
+3. /ant-plan                               (generates phases)
+4. /ant-focus "security"                   (optional guidance)
+5. /ant-build 1                            (workers execute phase 1)
+6. /ant-continue                           (verify, learn, advance)
+7. /ant-build 2                            (repeat until complete)
+   /ant-run                                (or use autopilot for all phases)
+
+After /clear or session break:
+8. /ant-resume-colony                      (restore full context)
+9. /ant-status                             (see where you left off)
+
+After completing a colony:
+10. /ant-seal                              (mark as complete)
+11. /ant-entomb                            (archive to chambers)
+12. /ant-init "next project goal"          (start fresh colony)
+```
+
+## Worker Castes
+
+Workers are assigned to castes based on task type:
+
+| Caste | Role |
+|-------|------|
+| builder | Implementation work |
+| watcher | Monitoring, quality checks |
+| scout | Research, discovery |
+| chaos | Edge case testing |
+| oracle | Deep research (RALF loop) |
+| architect | Planning, design |
+| colonizer | Codebase exploration |
+| route_setter | Phase planning |
+| archaeologist | Git history analysis |
+
+## Protected Paths
+
+**Never modify these programmatically:**
+
+| Path | Reason |
+|------|--------|
+| `.aether/data/` | Colony state (COLONY_STATE.json, session files) |
+| `.aether/dreams/` | Dream journal entries |
+| `.aether/checkpoints/` | Session checkpoints |
+| `.aether/locks/` | File locks |
+
+## Colony State
+
+State is stored in `.aether/data/COLONY_STATE.json` and includes:
+- Colony goal and current phase
+- Task breakdown and completion status
+- Instincts (learned patterns with confidence scores)
+- Pheromone signals (FOCUS/REDIRECT/FEEDBACK)
+- Event history
+
+## Pheromone System
+
+Signals guide colony behavior without hard-coding instructions:
+- **FOCUS** — attracts attention to an area (expires at phase end)
+- **REDIRECT** — repels workers from a pattern (high priority, hard constraint)
+- **FEEDBACK** — calibrates behavior based on observation (low priority)
+
+Use FOCUS + REDIRECT before builds to steer. Use FEEDBACK after builds to adjust.

--- a/cmd/codex_plan.go
+++ b/cmd/codex_plan.go
@@ -1112,29 +1112,39 @@ func renderPlanningWorkerBrief(root string, survey codexSurveyContext, spec plan
 		b.WriteString("- Survey docs to read first: none detected; inspect repo files only when the survey is missing or ambiguous.\n")
 	}
 	if spec.Caste == "route_setter" {
-		b.WriteString("- Read scout output before drafting phases: ")
+		b.WriteString("- Read scout output before drafting phases if it exists: ")
 		b.WriteString(filepath.ToSlash(filepath.Join(planningDir, "SCOUT.md")))
+		b.WriteString("; if it is missing, proceed from the survey context and note the missing scout artifact in blockers only if it prevents a useful plan.")
 		b.WriteString("\n")
 	}
 	b.WriteString("- Repo inspection rule: use targeted reads to confirm or extend survey findings; do not trawl the whole tree unless the survey lacks the needed detail.\n")
 	b.WriteString("- Avoid high-noise paths unless directly relevant: .aether/backups/, .aether/chambers/, .aether/data/build/, .git/, node_modules/, dist/, build/, vendor/.\n")
+	if spec.Caste == "scout" {
+		b.WriteString("- Scout scope rule: stay read-only, do not spawn subagents, and stop after the survey docs plus targeted confirmation reads are enough to summarize planning risks.\n")
+	}
 	graphTargets := append(append([]string{}, survey.EntryPoints...), survey.TestFiles...)
 	if graphContext := renderCodegraphContextForText(root, graphTargets, codegraphWorkerContextBudgetChars); graphContext != "" {
 		b.WriteString("\n")
 		b.WriteString(graphContext)
 		b.WriteString("\n\n")
 	}
-	b.WriteString("Write planning outputs directly into the repository.\n")
-	b.WriteString("- Primary outputs: ")
-	b.WriteString(strings.Join(primaryOutputs, ", "))
-	b.WriteString("\n")
-	b.WriteString("- Planning dir: ")
-	b.WriteString(planningDir)
-	b.WriteString("\n")
-	b.WriteString("- Phase research dir: ")
-	b.WriteString(phaseResearchDir)
-	b.WriteString("\n")
-	if spec.Caste == "route_setter" {
+	if spec.Caste == "scout" {
+		b.WriteString("Return planning findings in the final worker claims JSON only.\n")
+		b.WriteString("- Do not write files; Scout is read-only on every supported platform.\n")
+		b.WriteString("- Aether will persist the scout artifact after the worker completes: ")
+		b.WriteString(strings.Join(primaryOutputs, ", "))
+		b.WriteString("\n")
+	} else {
+		b.WriteString("Write planning outputs directly into the repository.\n")
+		b.WriteString("- Primary outputs: ")
+		b.WriteString(strings.Join(primaryOutputs, ", "))
+		b.WriteString("\n")
+		b.WriteString("- Planning dir: ")
+		b.WriteString(planningDir)
+		b.WriteString("\n")
+		b.WriteString("- Phase research dir: ")
+		b.WriteString(phaseResearchDir)
+		b.WriteString("\n")
 		b.WriteString("- Also write a machine-readable plan artifact at ")
 		b.WriteString(filepath.ToSlash(filepath.Join(planningDir, "phase-plan.json")))
 		b.WriteString(" using this JSON shape:\n")

--- a/cmd/codex_plan_test.go
+++ b/cmd/codex_plan_test.go
@@ -1088,13 +1088,21 @@ developer_instructions = "test instructions"`), 0644); err != nil {
 		".aether/data/build/",
 		".git/",
 		"node_modules/",
+		"Scout is read-only",
+		"do not spawn subagents",
 	} {
 		if !strings.Contains(invoker.briefs[0], want) {
 			t.Fatalf("scout brief missing %q:\n%s", want, invoker.briefs[0])
 		}
 	}
+	if strings.Contains(invoker.briefs[0], "Write planning outputs directly into the repository.") {
+		t.Fatalf("scout brief must not ask read-only Scout to write files:\n%s", invoker.briefs[0])
+	}
 	if !strings.Contains(invoker.briefs[1], ".aether/data/planning/SCOUT.md") {
 		t.Fatalf("route-setter brief missing scout artifact guidance:\n%s", invoker.briefs[1])
+	}
+	if !strings.Contains(invoker.briefs[1], "if it is missing, proceed from the survey context") {
+		t.Fatalf("route-setter brief should not hard-block on missing scout artifact:\n%s", invoker.briefs[1])
 	}
 }
 

--- a/cmd/install_cmd.go
+++ b/cmd/install_cmd.go
@@ -491,6 +491,57 @@ func syncPlatformHomeAssets(packageDir, homeDir string, channel runtimeChannel) 
 	return results, syncErrors
 }
 
+func syncPlatformHomeAssetsFromHub(hubDir, homeDir string, channel runtimeChannel) ([]map[string]interface{}, []string) {
+	results := []map[string]interface{}{}
+	var syncErrors []string
+
+	if !shouldSyncPlatformHomes(channel) {
+		return append(results, map[string]interface{}{
+			"label":   "Platform homes",
+			"src":     "hub/system",
+			"dest":    "skipped",
+			"copied":  0,
+			"skipped": 0,
+			"note":    "Dev channel leaves global Claude/OpenCode/Codex home assets untouched by default.",
+		}), syncErrors
+	}
+
+	hubSystem := filepath.Join(hubDir, "system")
+	for _, pair := range platformHomeHubSyncPairs() {
+		srcDir := filepath.Join(hubSystem, filepath.FromSlash(pair.srcRel))
+		destDir := filepath.Join(homeDir, filepath.FromSlash(pair.destRel))
+
+		result := syncDir(srcDir, destDir, syncOptions{
+			cleanup:              pair.cleanup,
+			preserveLocalChanges: pair.preserveLocalChanges,
+			validate:             pair.validate,
+			include:              pair.include,
+			mapRelPath:           pair.mapRelPath,
+			cleanupInclude:       pair.cleanupInclude,
+		})
+		if pair.cleanupLegacyClaude && pair.cleanup {
+			removed, errors := removeLegacyClaudeCommandNamespace(destDir)
+			result.removed = append(result.removed, removed...)
+			result.errors = append(result.errors, errors...)
+		}
+		entry := map[string]interface{}{
+			"label":   pair.label,
+			"src":     filepath.ToSlash(filepath.Join("system", pair.srcRel)),
+			"dest":    pair.destRel,
+			"copied":  result.copied,
+			"skipped": result.skipped,
+			"removed": len(result.removed),
+		}
+		if len(result.errors) > 0 {
+			entry["errors"] = result.errors
+			syncErrors = append(syncErrors, result.errors...)
+		}
+		results = append(results, entry)
+	}
+
+	return results, syncErrors
+}
+
 func filterSyncFiles(relPaths []string, include syncFilter) []string {
 	if include == nil {
 		return relPaths

--- a/cmd/platform_sync.go
+++ b/cmd/platform_sync.go
@@ -60,6 +60,16 @@ func installSyncPairs() []installSyncPair {
 	}
 }
 
+func platformHomeHubSyncPairs() []installSyncPair {
+	return []installSyncPair{
+		{srcRel: "commands/claude", destRel: ".claude/commands", label: "Commands (claude)", cleanup: true, mapRelPath: claudeCommandDestRelPath, cleanupInclude: isManagedFlatClaudeCommandPath, cleanupLegacyClaude: true},
+		{srcRel: "agents-claude", destRel: ".claude/agents/ant", label: "Agents (claude)", cleanup: true},
+		{srcRel: "commands/opencode", destRel: ".config/opencode/commands/ant", label: "Commands (opencode)", cleanup: true},
+		{srcRel: "agents", destRel: ".config/opencode/agents", label: "Agents (opencode)", cleanup: false, validate: validateOpenCodeAgentFile},
+		{srcRel: "codex", destRel: ".codex/agents", label: "Agents (codex)", cleanup: false, preserveLocalChanges: true, validate: validateCodexAgentFile, include: isShippedAetherCodexAgent},
+	}
+}
+
 func repoSyncPairs() []repoSyncPair {
 	return []repoSyncPair{
 		{

--- a/cmd/update_cmd.go
+++ b/cmd/update_cmd.go
@@ -97,6 +97,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 				"Ensure repo-local .aether/data, dreams, oracle, locks, QUEEN.md, and .gitignore",
 				"Prune stale generated repo-local agents, commands, and shipped skills",
 				"Refresh repo-level platform guidance (AGENTS.md, .codex/CODEX.md, .opencode/OPENCODE.md) when managed by Aether",
+				"Refresh global Claude/OpenCode/Codex commands and agents from the hub",
 				"Sync .claude/settings.json",
 				fmt.Sprintf("Do not change the installed %s binary unless --download-binary is also used", defaultBinaryName(channel)),
 			},
@@ -137,6 +138,24 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		syncResult.skipped += docSkipped
 		if len(docErrors) > 0 {
 			syncResult.errors = append(syncResult.errors, docErrors...)
+			outputError(2, fmt.Sprintf("update failed with %d sync error(s)", len(syncResult.errors)), map[string]interface{}{
+				"hub_version":         hubVersion,
+				"local_version":       resolveVersion(),
+				"force":               force,
+				"details":             syncResult.details,
+				"binary_refresh_mode": binaryMode,
+				"binary_refresh_note": updateBinaryRefreshNote(binaryMode, channel),
+			})
+			return nil
+		}
+		platformResults, platformErrors := syncPlatformHomeAssetsFromHub(hubDir, homeDir, channel)
+		syncResult.details = append(syncResult.details, platformResults...)
+		for _, entry := range platformResults {
+			syncResult.copied += intValue(entry["copied"])
+			syncResult.skipped += intValue(entry["skipped"])
+		}
+		if len(platformErrors) > 0 {
+			syncResult.errors = append(syncResult.errors, platformErrors...)
 			outputError(2, fmt.Sprintf("update failed with %d sync error(s)", len(syncResult.errors)), map[string]interface{}{
 				"hub_version":         hubVersion,
 				"local_version":       resolveVersion(),

--- a/cmd/update_cmd_test.go
+++ b/cmd/update_cmd_test.go
@@ -281,6 +281,81 @@ func TestRunUpdateSyncCopiesAllowedClaudeRepoFiles(t *testing.T) {
 	}
 }
 
+func TestSyncPlatformHomeAssetsFromHubRefreshesGlobalPlatformHomes(t *testing.T) {
+	saveGlobals(t)
+
+	hubDir := t.TempDir()
+	homeDir := t.TempDir()
+	systemDir := filepath.Join(hubDir, "system")
+
+	writeHubFile := func(rel string, data []byte) {
+		t.Helper()
+		path := filepath.Join(systemDir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatalf("create parent for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, data, 0644); err != nil {
+			t.Fatalf("write hub %s: %v", rel, err)
+		}
+	}
+
+	claudeCommand := []byte("<!-- Generated from .aether/commands/build.yaml - DO NOT EDIT DIRECTLY -->\n# Build from hub\n")
+	claudeAgent := []byte("---\nname: aether-builder\ndescription: Builder agent\n---\n# Claude Builder\n")
+	openCodeCommand := []byte("# OpenCode Build from hub\n")
+	openCodeAgent := []byte("---\n" + validAgentFrontmatter + "\n---\n\n# OpenCode Builder\n")
+	codexAgent := validCodexAgentTOML("aether-builder", "builder")
+
+	writeHubFile(filepath.Join("commands", "claude", "build.md"), claudeCommand)
+	writeHubFile(filepath.Join("agents-claude", "aether-builder.md"), claudeAgent)
+	writeHubFile(filepath.Join("commands", "opencode", "build.md"), openCodeCommand)
+	writeHubFile(filepath.Join("agents", "aether-builder.md"), openCodeAgent)
+	writeHubFile(filepath.Join("codex", "aether-builder.toml"), codexAgent)
+
+	staleClaudeCommand := filepath.Join(homeDir, ".claude", "commands", "ant-build.md")
+	if err := os.MkdirAll(filepath.Dir(staleClaudeCommand), 0755); err != nil {
+		t.Fatalf("create stale Claude command parent: %v", err)
+	}
+	if err := os.WriteFile(staleClaudeCommand, []byte("stale\n"), 0644); err != nil {
+		t.Fatalf("write stale Claude command: %v", err)
+	}
+	customOpenCodeAgent := filepath.Join(homeDir, ".config", "opencode", "agents", "mds-implementer.md")
+	if err := os.MkdirAll(filepath.Dir(customOpenCodeAgent), 0755); err != nil {
+		t.Fatalf("create custom OpenCode agent parent: %v", err)
+	}
+	if err := os.WriteFile(customOpenCodeAgent, []byte("# Custom MDS agent\n"), 0644); err != nil {
+		t.Fatalf("write custom OpenCode agent: %v", err)
+	}
+
+	results, errors := syncPlatformHomeAssetsFromHub(hubDir, homeDir, channelStable)
+	if len(errors) > 0 {
+		t.Fatalf("syncPlatformHomeAssetsFromHub errors: %v", errors)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected platform sync results")
+	}
+
+	assertFileContent := func(rel string, want []byte) {
+		t.Helper()
+		got, err := os.ReadFile(filepath.Join(homeDir, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if string(got) != string(want) {
+			t.Fatalf("%s content mismatch\ngot:\n%s\nwant:\n%s", rel, string(got), string(want))
+		}
+	}
+
+	assertFileContent(filepath.Join(".claude", "commands", "ant-build.md"), claudeCommand)
+	assertFileContent(filepath.Join(".claude", "agents", "ant", "aether-builder.md"), claudeAgent)
+	assertFileContent(filepath.Join(".config", "opencode", "commands", "ant", "build.md"), openCodeCommand)
+	assertFileContent(filepath.Join(".config", "opencode", "agents", "aether-builder.md"), openCodeAgent)
+	assertFileContent(filepath.Join(".codex", "agents", "aether-builder.toml"), codexAgent)
+
+	if _, err := os.Stat(customOpenCodeAgent); err != nil {
+		t.Fatalf("custom OpenCode agent should be preserved: %v", err)
+	}
+}
+
 func TestCheckStalePublishExpectedCounts(t *testing.T) {
 	hubDir := t.TempDir()
 	createHubWithExpectedCounts(t, hubDir)
@@ -311,7 +386,26 @@ func createHubWithExpectedCounts(t *testing.T, hubDir string) {
 			ext = ".toml"
 		}
 		for i := 0; i < count; i++ {
-			if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("file_%02d%s", i, ext)), []byte("# test"), 0644); err != nil {
+			content := []byte("# test")
+			if filepath.ToSlash(rel) == "agents" {
+				content = []byte(fmt.Sprintf(`---
+name: aether-fixture-%02d
+description: "OpenCode fixture agent used for update and stale publish tests"
+mode: subagent
+color: "#3b82f6"
+tools:
+  write: true
+  edit: true
+  bash: true
+  grep: true
+  glob: true
+  task: true
+---
+
+# OpenCode fixture agent
+`, i))
+			}
+			if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("file_%02d%s", i, ext)), content, 0644); err != nil {
 				t.Fatalf("write %s fixture: %v", rel, err)
 			}
 		}


### PR DESCRIPTION
## Summary
- Refresh global Claude, OpenCode, and Codex command/agent homes during aether update, using the published hub as source.
- Preserve custom OpenCode agents while refreshing shipped Aether agents.
- Fix planning worker prompts so read-only Scout is not asked to write files, and Route-Setter does not hard-block on a missing scout artifact.
- Track the shipped .aether/rules/aether-colony.md asset so fresh checkouts can build embedded assets.

## Tests
- go test ./cmd
- go test ./...

## Publish
- go run ./cmd/aether publish --channel stable --binary-dest "$HOME/.local/bin"
