### PR TITLE
Fix hosted planning agent delegation

### DIFF
--- a/.aether/commands/plan.yaml
+++ b/.aether/commands/plan.yaml
@@ -25,13 +25,14 @@ wrapper_additions:
   orchestration: |
     Restore real wrapper planning orchestration:
     1. Run `AETHER_OUTPUT_MODE=visual aether status`.
-    2. Run `AETHER_OUTPUT_MODE=json aether plan --plan-only --depth <choice> --planning-depth <choice2>`.
+    2. Run `AETHER_OUTPUT_MODE=json aether plan --plan-only --depth <choice> --planning-depth <choice2>` for normal wrapper planning, or run the user's requested `aether plan --refresh` when refreshing an existing plan.
     3. Parse `result.plan_manifest` or `result.planning_manifest`; do not parse visual output.
-    4. If the result reports `unresolved_clarifications` or `clarification_warning`, pause before spawning workers and route first to `/ant-discuss`; proceed with implicit assumptions only if the user explicitly chooses to continue.
-    5. Spawn Scout from wave 1, then Route-Setter from wave 2, using manifest names, castes, task IDs, briefs, `agent_name`, and each dispatch's runtime-provided `skill_section` when present.
-    6. Call `aether spawn-log` before each worker and `aether spawn-complete` after each terminal result.
-    7. Collect terminal worker results into a completion JSON file outside `.aether/data/`.
-    8. Run `AETHER_OUTPUT_MODE=json aether plan-finalize --completion-file <file>` to let the runtime write canonical planning artifacts and state.
+    4. If the runtime reports `dispatch_mode: agent-delegate`, treat it as the same host-dispatch contract: do not run nested subprocess planning; dispatch the manifest workers through the current host platform and finish with `plan-finalize`.
+    5. If the result reports `unresolved_clarifications` or `clarification_warning`, pause before spawning workers and route first to `/ant-discuss`; proceed with implicit assumptions only if the user explicitly chooses to continue.
+    6. Spawn Scout from wave 1, then Route-Setter from wave 2, using manifest names, castes, task IDs, briefs, `agent_name`, and each dispatch's runtime-provided `skill_section` when present.
+    7. Call `aether spawn-log` before each worker and `aether spawn-complete` after each terminal result.
+    8. Collect terminal worker results into a completion JSON file outside `.aether/data/`.
+    9. Run `AETHER_OUTPUT_MODE=json aether plan-finalize --completion-file <file>` to let the runtime write canonical planning artifacts and state.
   post_plan: |
     Close from the `plan-finalize` result only:
     1. Summarize selected depth and planning depth, phase count, confidence, and which planning agents ran.

--- a/.claude/commands/ant/plan.md
+++ b/.claude/commands/ant/plan.md
@@ -51,6 +51,8 @@ AETHER_OUTPUT_MODE=json aether plan --plan-only --depth <choice> --planning-dept
 
 Parse `result.plan_manifest` or `result.planning_manifest`. This manifest is the only source for worker names, castes, waves, task IDs, briefs, survey context, depth, granularity bounds, and finalizer contract.
 
+If the user requested a refresh and the runtime returns `dispatch_mode: agent-delegate`, do not run nested subprocess planning. Treat the returned manifest as the same host-dispatch contract: dispatch Scout and Route-Setter through the current platform, then finish with `plan-finalize`.
+
 If the runtime returns `existing_plan: true`, do not spawn workers. Summarize the existing plan and route to the runtime-surfaced next command.
 
 ## Clarification Gate

--- a/.opencode/commands/ant/plan.md
+++ b/.opencode/commands/ant/plan.md
@@ -51,6 +51,8 @@ AETHER_OUTPUT_MODE=json aether plan --plan-only --depth <choice> --planning-dept
 
 Parse `result.plan_manifest` or `result.planning_manifest`. This manifest is the only source for worker names, castes, waves, task IDs, briefs, survey context, depth, granularity bounds, and finalizer contract.
 
+If the user requested a refresh and the runtime returns `dispatch_mode: agent-delegate`, do not run nested subprocess planning. Treat the returned manifest as the same host-dispatch contract: dispatch Scout and Route-Setter through the current platform, then finish with `plan-finalize`.
+
 If the runtime returns `existing_plan: true`, do not spawn workers. Summarize the existing plan and route to the runtime-surfaced next command.
 
 ## Clarification Gate

--- a/cmd/codex_plan.go
+++ b/cmd/codex_plan.go
@@ -225,6 +225,10 @@ func runCodexPlanWithOptions(root string, opts codexPlanOptions) (map[string]int
 		}, nil
 	}
 
+	if codex.ShouldUseAgentDelegatePath() {
+		return runCodexPlanAgentDelegate(root, state, granularity, planDepth, unresolvedClarifications, clarificationWarning, opts)
+	}
+
 	if opts.Refresh {
 		if state.CurrentPhase > 0 {
 			hasCompletedPhase := false
@@ -477,6 +481,33 @@ func runCodexPlanWithOptions(root string, opts codexPlanOptions) (map[string]int
 		statuses = append(statuses, dispatch.Status)
 	}
 	runStatus = summarizeRunStatus(statuses...)
+	return result, nil
+}
+
+func runCodexPlanAgentDelegate(root string, state colony.ColonyState, granularity colony.PlanGranularity, planDepth string, unresolvedClarifications int, clarificationWarning string, opts codexPlanOptions) (map[string]interface{}, error) {
+	result, err := runCodexPlanPlanOnly(root, state, granularity, planDepth, unresolvedClarifications, clarificationWarning, opts)
+	if err != nil {
+		return nil, err
+	}
+	manifest, ok := result["plan_manifest"].(codexPlanManifest)
+	if !ok {
+		return result, nil
+	}
+	manifest.DispatchMode = "agent-delegate"
+	result["plan_manifest"] = manifest
+	result["planning_manifest"] = manifest
+	result["agent_delegate"] = true
+	result["status"] = "agent-delegate"
+	result["dispatch_mode"] = "agent-delegate"
+	result["requires_finalizer"] = true
+	result["agent_delegate_reason"] = codex.AgentDelegateFallbackReason()
+	result["next"] = "dispatch host planning agents, then run `aether plan-finalize --completion-file <file>`"
+	if contract, ok := result["wrapper_contract"].(map[string]interface{}); ok {
+		contract["source_command"] = "AETHER_OUTPUT_MODE=json aether plan --refresh"
+		contract["dispatch_mode"] = "agent-delegate"
+		contract["finalize_command"] = "AETHER_OUTPUT_MODE=json aether plan-finalize --completion-file <file>"
+		result["wrapper_contract"] = contract
+	}
 	return result, nil
 }
 

--- a/cmd/codex_plan_finalize.go
+++ b/cmd/codex_plan_finalize.go
@@ -108,8 +108,8 @@ func runCodexPlanFinalize(root string, completion codexExternalPlanCompletion) (
 	if manifest == nil {
 		return nil, fmt.Errorf("completion file must include plan_manifest")
 	}
-	if manifest.DispatchMode != "plan-only" || !manifest.RequiresFinalizer {
-		return nil, fmt.Errorf("plan_manifest must come from `aether plan --plan-only`")
+	if (manifest.DispatchMode != "plan-only" && manifest.DispatchMode != "agent-delegate") || !manifest.RequiresFinalizer {
+		return nil, fmt.Errorf("plan_manifest must come from `aether plan --plan-only` or an agent-delegate planning response")
 	}
 	if len(manifest.Dispatches) == 0 {
 		return nil, fmt.Errorf("plan_manifest contains no dispatches")

--- a/cmd/codex_plan_test.go
+++ b/cmd/codex_plan_test.go
@@ -274,6 +274,80 @@ func TestPlanOnlyPrintsManifestWithoutMutatingState(t *testing.T) {
 	}
 }
 
+func TestPlanRefreshUsesAgentDelegatePathInsideHostedAgent(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+	setupRuntimeSkillAssignmentHub(t)
+	t.Setenv("AETHER_OUTPUT_MODE", "json")
+	t.Setenv("AETHER_ACTIVE_PLATFORM", "opencode")
+	t.Setenv("OPENCODE_AGENT", "1")
+
+	dataDir := setupBuildFlowTest(t)
+	root := filepath.Dir(filepath.Dir(dataDir))
+	withWorkingDir(t, root)
+
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/aether-plan-agent-delegate-test\n\ngo 1.24\n"), 0644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+
+	goal := "Refresh planning without nested subprocess workers"
+	taskID := "task-1"
+	createTestColonyState(t, dataDir, colony.ColonyState{
+		Version:      "3.0",
+		Goal:         &goal,
+		State:        colony.StateEXECUTING,
+		CurrentPhase: 1,
+		Plan: colony.Plan{Phases: []colony.Phase{{
+			ID:     1,
+			Name:   "Stale plan",
+			Status: colony.PhaseInProgress,
+			Tasks:  []colony.Task{{ID: &taskID, Goal: "Old task", Status: colony.TaskInProgress}},
+		}}},
+	})
+
+	rootCmd.SetArgs([]string{"plan", "--refresh", "--depth", "fast"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("plan --refresh returned error: %v", err)
+	}
+
+	env := parseEnvelope(t, stdout.(*bytes.Buffer).String())
+	result := env["result"].(map[string]interface{})
+	if result["dispatch_mode"].(string) != "agent-delegate" {
+		t.Fatalf("dispatch_mode = %q, want agent-delegate", result["dispatch_mode"])
+	}
+	if result["agent_delegate"] != true {
+		t.Fatalf("agent_delegate = %v, want true", result["agent_delegate"])
+	}
+	if result["requires_finalizer"] != true {
+		t.Fatalf("requires_finalizer = %v, want true", result["requires_finalizer"])
+	}
+	manifest := result["plan_manifest"].(map[string]interface{})
+	if manifest["dispatch_mode"].(string) != "agent-delegate" || manifest["requires_finalizer"] != true {
+		t.Fatalf("unexpected manifest mode/finalizer: %+v", manifest)
+	}
+	if manifest["refresh"] != true {
+		t.Fatalf("manifest refresh = %v, want true", manifest["refresh"])
+	}
+	dispatches := manifest["dispatches"].([]interface{})
+	if len(dispatches) != 2 {
+		t.Fatalf("expected 2 planning dispatches, got %d", len(dispatches))
+	}
+	for _, rel := range []string{"planning", "phase-research", "spawn-tree.txt", "runtime-spawn-runs.jsonl"} {
+		if _, err := os.Stat(filepath.Join(dataDir, rel)); err == nil {
+			t.Fatalf("agent-delegate plan unexpectedly wrote %s", rel)
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", rel, err)
+		}
+	}
+	var state colony.ColonyState
+	if err := store.LoadJSON("COLONY_STATE.json", &state); err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if state.CurrentPhase != 1 || len(state.Plan.Phases) != 1 || state.Plan.Phases[0].Status != colony.PhaseInProgress {
+		t.Fatalf("agent-delegate plan mutated stale phase state before finalize: %+v", state)
+	}
+}
+
 func TestPlanDepthMapsToGranularityBounds(t *testing.T) {
 	tests := []struct {
 		depth       string
@@ -468,6 +542,23 @@ func TestPlanFinalizeRecordsExternalPlanningAndWritesState(t *testing.T) {
 	}
 	if !strings.Contains(string(contextData), "aether build 1") {
 		t.Fatalf("CONTEXT.md missing next build guidance:\n%s", string(contextData))
+	}
+}
+
+func TestPlanFinalizeAcceptsAgentDelegateManifestMode(t *testing.T) {
+	saveGlobals(t)
+	s, _ := newTestStore(t)
+	store = s
+
+	_, err := runCodexPlanFinalize(t.TempDir(), codexExternalPlanCompletion{
+		PlanManifest: &codexPlanManifest{
+			Goal:              "Agent delegate planning",
+			DispatchMode:      "agent-delegate",
+			RequiresFinalizer: true,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "contains no dispatches") {
+		t.Fatalf("expected agent-delegate manifest to pass mode validation and fail on dispatches, got %v", err)
 	}
 }
 

--- a/cmd/codex_visuals.go
+++ b/cmd/codex_visuals.go
@@ -963,6 +963,19 @@ func renderPlanVisual(result map[string]interface{}) string {
 	}
 	if planOnly, _ := result["plan_only"].(bool); planOnly {
 		if existing, _ := result["existing_plan"].(bool); !existing {
+			if agentDelegate, _ := result["agent_delegate"].(bool); agentDelegate || strings.TrimSpace(stringValue(result["dispatch_mode"])) == "agent-delegate" {
+				if reason := strings.TrimSpace(stringValue(result["agent_delegate_reason"])); reason != "" {
+					b.WriteString("Agent-Delegate\n")
+					b.WriteString("  - ")
+					b.WriteString(reason)
+					b.WriteString("\n\n")
+				}
+				b.WriteString(renderNextUp(
+					`Host platform should dispatch the JSON `+"`plan_manifest`"+` Scout and Route-Setter workers.`,
+					`After they finish, run `+"`aether plan-finalize --completion-file <file>`"+` to write the plan.`,
+				))
+				return b.String()
+			}
 			b.WriteString(renderNextUp(
 				`Use the JSON `+"`plan_manifest`"+` to spawn wrapper Scout and Route-Setter agents.`,
 				`This surface is read-only; pair it with the plan finalizer before replacing the normal `+"`aether plan`"+` flow.`,

--- a/cmd/codex_visuals_test.go
+++ b/cmd/codex_visuals_test.go
@@ -1441,6 +1441,34 @@ func TestRenderPlanVisual_SimulatedDispatch(t *testing.T) {
 	}
 }
 
+func TestRenderPlanVisualAgentDelegatePlanOnly(t *testing.T) {
+	result := map[string]interface{}{
+		"plan_only":             true,
+		"agent_delegate":        true,
+		"existing_plan":         false,
+		"goal":                  "Refresh plan through host agents",
+		"granularity":           "sprint",
+		"dispatch_mode":         "agent-delegate",
+		"agent_delegate_reason": "agent-delegate session detected on opencode; host platform must dispatch workers directly",
+		"dispatches": []interface{}{
+			map[string]interface{}{"name": "Seek-40", "caste": "scout", "task": "Survey the repo", "status": "planned"},
+			map[string]interface{}{"name": "Carrier-52", "caste": "route_setter", "task": "Convert findings into phases", "status": "planned"},
+		},
+	}
+
+	output := renderPlanVisual(result)
+	for _, want := range []string{
+		"Agent-Delegate",
+		"host platform must dispatch workers directly",
+		"Host platform should dispatch the JSON `plan_manifest` Scout and Route-Setter workers.",
+		"`aether plan-finalize --completion-file <file>`",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("agent-delegate plan visual missing %q\n%s", want, output)
+		}
+	}
+}
+
 func TestRenderPlanVisual_RealDispatch(t *testing.T) {
 	// When planning workers have "completed" or "failed" status, show execution data.
 	phases := []colony.Phase{

--- a/cmd/command_guide.go
+++ b/cmd/command_guide.go
@@ -192,6 +192,7 @@ func commandGuideCatalog() map[string]commandGuideDefinition {
 			"Select planning depth and decomposition depth with the user unless arguments already specify them.",
 			"Run `AETHER_OUTPUT_MODE=visual aether status` for current colony context.",
 			"Run `AETHER_OUTPUT_MODE=json aether plan --plan-only --depth <choice> --planning-depth <choice>` and parse `result.plan_manifest` or `result.planning_manifest`.",
+			"If runtime returns `dispatch_mode: agent-delegate`, dispatch Scout and Route-Setter through the host platform instead of nested subprocess workers, then finalize with the returned manifest.",
 			"If runtime reports unresolved clarifications, route to `aether discuss` before spawning planning workers unless the user explicitly approves assumptions.",
 		},
 		RunCommand: "AETHER_OUTPUT_MODE=json aether plan-finalize --completion-file <worker completion JSON>",

--- a/pkg/codex/platform_dispatch.go
+++ b/pkg/codex/platform_dispatch.go
@@ -218,6 +218,29 @@ func IsAgentDelegateSession() bool {
 	return false
 }
 
+func ShouldUseAgentDelegatePath() bool {
+	if !IsAgentDelegateSession() {
+		return false
+	}
+	switch DetectActivePlatform() {
+	case PlatformClaude, PlatformOpenCode:
+		return true
+	default:
+		return false
+	}
+}
+
+func AgentDelegateFallbackReason() string {
+	platform := DetectActivePlatform()
+	if platform == PlatformUnknown {
+		return "agent-delegate session detected; active platform is unknown"
+	}
+	if platform != PlatformClaude && platform != PlatformOpenCode {
+		return fmt.Sprintf("agent-delegate session detected on %s; nested worker dispatch remains local", platform)
+	}
+	return fmt.Sprintf("agent-delegate session detected on %s; host platform must dispatch workers directly", platform)
+}
+
 func DetectActivePlatform() Platform {
 	if platform := normalizePlatform(os.Getenv(envActivePlatform)); platform != PlatformUnknown {
 		return platform

--- a/pkg/codex/platform_dispatch_test.go
+++ b/pkg/codex/platform_dispatch_test.go
@@ -228,9 +228,9 @@ EOF
 
 func TestIsAgentDelegateSession(t *testing.T) {
 	tests := []struct {
-		name     string
-		envVars  map[string]string
-		want     bool
+		name    string
+		envVars map[string]string
+		want    bool
 	}{
 		{
 			name:    "no env vars set",
@@ -325,6 +325,55 @@ func TestIsAgentDelegateSession(t *testing.T) {
 			got := IsAgentDelegateSession()
 			if got != tt.want {
 				t.Fatalf("IsAgentDelegateSession() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldUseAgentDelegatePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVars  map[string]string
+		platform string
+		want     bool
+	}{
+		{
+			name:     "claude agent session",
+			envVars:  map[string]string{"CLAUDE_CODE_SIMPLE": "1"},
+			platform: "claude",
+			want:     true,
+		},
+		{
+			name:     "opencode agent session",
+			envVars:  map[string]string{"OPENCODE_AGENT": "1"},
+			platform: "opencode",
+			want:     true,
+		},
+		{
+			name:     "codex session stays local",
+			envVars:  map[string]string{"AETHER_AGENT_DELEGATE": "1"},
+			platform: "codex",
+			want:     false,
+		},
+		{
+			name:     "claude platform without delegate marker",
+			envVars:  map[string]string{},
+			platform: "claude",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, key := range []string{"CLAUDE_CODE_SIMPLE", "OPENCODE_AGENT", "AETHER_AGENT_DELEGATE"} {
+				t.Setenv(key, "")
+			}
+			t.Setenv(envActivePlatform, tt.platform)
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+			if got := ShouldUseAgentDelegatePath(); got != tt.want {
+				t.Fatalf("ShouldUseAgentDelegatePath() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- return an agent-delegate planning manifest from `aether plan --refresh` inside Claude/OpenCode agent sessions
- allow plan-finalize to consume agent-delegate manifests
- update plan visuals, command guide, and Claude/OpenCode plan wrapper docs

## Verification
- go test ./cmd -run 'PlanRefreshUsesAgentDelegate|PlanFinalizeAcceptsAgentDelegate|RenderPlanVisualAgentDelegate|PlanOnlyPrintsManifest' -count=1\n- go test ./cmd -count=1\n- go test ./...\n- go test ./... -race\n- go vet ./...\n- goreleaser check\n- manual smoke: OpenCode agent env plan --refresh returns dispatch_mode agent-delegate with 2 dispatches and requires_finalizer true