### PR TITLE
Isolate Porter test output mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Docs
 - AGENTS.md: add Runtime Lifecycle mermaid diagram (under Architecture Overview) and Wisdom Pipeline mermaid diagram (under Wisdom Pipeline). Model-agnostic, shows both `in-repo` and `worktree` parallel modes, and contains the `skill-match` sub-graph.
 
+## [1.0.28] - 2026-05-05
+
+Stabilize hosted-agent planning, Oracle runtime, and hub-backed platform updates.
+
+### Fixed
+- `aether plan --refresh` now returns an agent-delegate manifest inside hosted Claude Code and OpenCode agent sessions instead of spawning nested planning workers.
+- `aether oracle` now auto-detaches from hosted Claude/OpenCode agent sessions and no longer falls back to fake Oracle worker completion when no real dispatcher is available.
+- `aether update --force` now refreshes global Claude, OpenCode, and Codex platform assets from the hub while preserving custom user agents.
+- Oracle process handling now works across Unix and Windows snapshot builds.
+- Porter test verification now clears inherited `AETHER_OUTPUT_MODE` before running `go test`, avoiding false failures when Porter itself is rendered as JSON.
+
 ## [1.0.20] - 2026-04-23
 
 Truth recovery and platform parity checkpoint release.

--- a/cmd/porter_cmd.go
+++ b/cmd/porter_cmd.go
@@ -353,6 +353,7 @@ func checkTestStatus() integrityCheck {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "go", "test", "./...", "-count=1")
+	cmd.Env = porterTestEnv(os.Environ())
 	output, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
 		return integrityCheck{
@@ -383,14 +384,37 @@ func checkTestStatus() integrityCheck {
 	}
 }
 
+func porterTestEnv(environ []string) []string {
+	out := make([]string, 0, len(environ)+1)
+	outputModeSet := false
+	for _, entry := range environ {
+		key := entry
+		if idx := strings.IndexByte(entry, '='); idx >= 0 {
+			key = entry[:idx]
+		}
+		if key == "AETHER_OUTPUT_MODE" {
+			if !outputModeSet {
+				out = append(out, "AETHER_OUTPUT_MODE=")
+				outputModeSet = true
+			}
+			continue
+		}
+		out = append(out, entry)
+	}
+	if !outputModeSet {
+		out = append(out, "AETHER_OUTPUT_MODE=")
+	}
+	return out
+}
+
 // checkChangelogCompleteness reads CHANGELOG.md and checks for an entry matching
 // the current source version.
 func checkChangelogCompleteness() integrityCheck {
 	version := resolveSourceVersion()
 	if version == "unknown" {
 		return integrityCheck{
-			Name:   "Changelog completeness",
-			Status: "skip",
+			Name:    "Changelog completeness",
+			Status:  "skip",
 			Message: "Source version unknown, cannot verify changelog",
 		}
 	}
@@ -406,9 +430,9 @@ func checkChangelogCompleteness() integrityCheck {
 			}
 		}
 		return integrityCheck{
-			Name:            "Changelog completeness",
-			Status:          "skip",
-			Message:         fmt.Sprintf("Cannot read CHANGELOG.md: %v", err),
+			Name:    "Changelog completeness",
+			Status:  "skip",
+			Message: fmt.Sprintf("Cannot read CHANGELOG.md: %v", err),
 		}
 	}
 

--- a/cmd/porter_cmd_test.go
+++ b/cmd/porter_cmd_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -39,15 +40,15 @@ func TestPorterCheckIncludesIntegrityChecks(t *testing.T) {
 	// Running inside the Aether source repo, so source checks apply
 	checks := buildPorterChecks("stable", true)
 	expectedNames := map[string]bool{
-		"Source version":        false,
-		"Binary version":        false,
-		"Hub version":           false,
-		"Hub companion files":   false,
-		"Downstream simulation": false,
-		"Git status":            false,
-		"Git stashes":           false,
-		"Git worktrees":         false,
-		"Test status":           false,
+		"Source version":         false,
+		"Binary version":         false,
+		"Hub version":            false,
+		"Hub companion files":    false,
+		"Downstream simulation":  false,
+		"Git status":             false,
+		"Git stashes":            false,
+		"Git worktrees":          false,
+		"Test status":            false,
 		"Changelog completeness": false,
 	}
 	for _, c := range checks {
@@ -153,6 +154,30 @@ func TestCheckGitWorktreesFunction(t *testing.T) {
 	}
 	if result.Status == "fail" && result.RecoveryCommand == "" {
 		t.Error("failed git worktrees check should have recovery command")
+	}
+}
+
+func TestPorterTestEnvClearsOutputMode(t *testing.T) {
+	env := porterTestEnv([]string{
+		"KEEP_ME=1",
+		"AETHER_OUTPUT_MODE=json",
+		"AETHER_OUTPUT_MODE=visual",
+	})
+
+	if !containsString(env, "KEEP_ME=1") {
+		t.Fatal("expected unrelated environment variable to be preserved")
+	}
+	count := 0
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "AETHER_OUTPUT_MODE=") {
+			count++
+			if entry != "AETHER_OUTPUT_MODE=" {
+				t.Fatalf("expected AETHER_OUTPUT_MODE to be cleared, got %q", entry)
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected one cleared AETHER_OUTPUT_MODE entry, got %d in %v", count, env)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Clear inherited AETHER_OUTPUT_MODE before Porter runs its internal go test subprocess.
- Add regression coverage for the sanitized Porter test environment.
- Add the missing 1.0.28 changelog entry for the current release train.

## Verification
- go test ./cmd -run 'TestPorter|TestCheckGit|TestCheckChangelog' -count=1
- AETHER_OUTPUT_MODE=json go run ./cmd/aether porter check --json (Test status and changelog now pass; remaining failures are existing stashes and Aether-aider worktree)
- go test ./... -count=1
- go test ./... -race -count=1
- go vet ./...
- npm --prefix npm test
- npm pack --dry-run
- go build ./cmd/aether
- goreleaser build --snapshot --clean