### PR TITLE
Fix command-center planning fallback

### DIFF
--- a/cmd/codex_plan.go
+++ b/cmd/codex_plan.go
@@ -1381,7 +1381,7 @@ func synthesizeRouteSetterPlan(goal string, granularity colony.PlanGranularity, 
 func planningTemplates(goal string, survey codexSurveyContext, report codexScoutReport) []phaseTemplate {
 	goalLower := strings.ToLower(goal)
 	switch {
-	case containsAny(goalLower, []string{"parity", "orchestrat", "workflow", "command", "spawn"}):
+	case isAetherOrchestrationGoal(goalLower):
 		return []phaseTemplate{
 			{
 				Name:        "Contract and gap mapping",
@@ -1743,6 +1743,17 @@ func isLanguageDesignGoal(goalLower string) bool {
 		"language", "grammar", "syntax", "parser", "lexer", "compiler", "transpil", "dsl",
 		"protocol", "serialization", "encode", "decode", "format", "schema", "spec",
 		"communication", "token efficien", "context efficien", "ai-to-ai",
+	})
+}
+
+func isAetherOrchestrationGoal(goalLower string) bool {
+	if !containsAny(goalLower, []string{"parity", "orchestrat", "workflow", "command", "spawn"}) {
+		return false
+	}
+	return containsAny(goalLower, []string{
+		"aether", "codex", "claude", "opencode", "colony", "ant",
+		"worker", "watcher", "builder", "scout", "route-setter",
+		"plan-only", "finalize", "spawn tree", "dispatch",
 	})
 }
 

--- a/cmd/codex_plan_test.go
+++ b/cmd/codex_plan_test.go
@@ -1071,6 +1071,76 @@ func TestPlanFallbackDefaultMilestoneUsesArchitecturePhase(t *testing.T) {
 	}
 }
 
+func TestPlanFallbackDoesNotTreatCommandCenterAsAetherCommandWork(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+
+	dataDir := setupBuildFlowTest(t)
+	root := filepath.Dir(filepath.Dir(dataDir))
+	withWorkingDir(t, root)
+
+	goal := "Redesign the dashboard as a premium personal command center"
+	createTestColonyState(t, dataDir, colony.ColonyState{
+		Version:         "3.0",
+		Goal:            &goal,
+		State:           colony.StateREADY,
+		PlanGranularity: colony.GranularityMilestone,
+		Plan:            colony.Plan{Phases: []colony.Phase{}},
+	})
+
+	originalInvoker := newCodexWorkerInvoker
+	newCodexWorkerInvoker = func() codex.WorkerInvoker { return &failingPlanningInvoker{} }
+	defer func() { newCodexWorkerInvoker = originalInvoker }()
+
+	rootCmd.SetArgs([]string{"plan"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("plan returned error: %v", err)
+	}
+
+	env := parseEnvelope(t, stdout.(*bytes.Buffer).String())
+	result := env["result"].(map[string]interface{})
+	if got := result["dispatch_mode"]; got != "fallback" {
+		t.Fatalf("dispatch_mode = %v, want fallback", got)
+	}
+
+	blob := ""
+	for _, raw := range result["phases"].([]interface{}) {
+		phase := raw.(map[string]interface{})
+		blob += phase["name"].(string) + "\n"
+		for _, taskRaw := range phase["tasks"].([]interface{}) {
+			task := taskRaw.(map[string]interface{})
+			blob += task["goal"].(string) + "\n"
+		}
+	}
+
+	for _, unwanted := range []string{
+		"Contract and gap mapping",
+		"Colonize orchestration",
+		"Planning orchestration",
+		"Build orchestration",
+		"Continue orchestration",
+		"Codex command behavior",
+		"ant workflow",
+	} {
+		if strings.Contains(blob, unwanted) {
+			t.Fatalf("command-center fallback should not produce Aether orchestration plan containing %q:\n%s", unwanted, blob)
+		}
+	}
+	if strings.TrimSpace(blob) == "" {
+		t.Fatal("expected command-center fallback to produce non-empty non-Aether plan")
+	}
+}
+
+func TestPlanFallbackStillSupportsExplicitAetherCommandWork(t *testing.T) {
+	templates := planningTemplates("Fix Codex command orchestration parity for Aether workers", codexSurveyContext{}, codexScoutReport{})
+	if len(templates) == 0 {
+		t.Fatal("expected templates")
+	}
+	if templates[0].Name != "Contract and gap mapping" {
+		t.Fatalf("first template = %q, want Contract and gap mapping", templates[0].Name)
+	}
+}
+
 // --- dispatchRealPlanningWorkers tests ---
 
 func TestDispatchRealPlanningWorkers_NilInvoker_ReturnsNil(t *testing.T) {


### PR DESCRIPTION
## Summary
- Stop treating any goal containing the word command as Aether command-orchestration work.
- Require Aether/Codex/Claude/OpenCode/colony/worker context before using the internal orchestration fallback template.
- Add regression coverage for dashboard/personal command center goals and keep explicit Aether command work supported.

## Verification
- go test ./cmd -run 'TestPlanFallback' -count=1
- go test ./cmd -count=1
- go test ./... -count=1
- go vet ./...