### PR TITLE
Restore host-orchestrated colonize flow

### DIFF
--- a/.aether/commands/colonize.yaml
+++ b/.aether/commands/colonize.yaml
@@ -1,8 +1,29 @@
 name: ant-colonize
-description: "🗺️ Survey territory with 4 parallel scouts for comprehensive colony intelligence"
+description: "🗺️ Survey territory with visible platform Surveyor workers"
 source_of_truth: "Use the Go `aether` CLI as the source of truth."
 runtime:
-  command: "AETHER_OUTPUT_MODE=visual aether colonize $ARGUMENTS"
+  command: "AETHER_OUTPUT_MODE=json aether colonize --plan-only $ARGUMENTS"
+codex_orchestration:
+  category: "full-orchestration"
+  skill: "aether-colony-build-cycle"
+  guide: "aether command-guide colonize --platform codex"
+  drift_guard: "Update this YAML, Claude/OpenCode wrappers, the Codex skill, and cmd/command_guide.go together."
+wrapper_additions:
+  orchestration: |
+    Restore host-visible surveyor orchestration:
+    1. Run `AETHER_OUTPUT_MODE=json aether colonize --plan-only $ARGUMENTS`.
+    2. Parse `result.colonize_manifest`; do not parse visual output.
+    3. For each manifest dispatch, call `aether spawn-log`, spawn the matching platform agent (`subagent_type` / equivalent) using `agent_name`, inject the dispatch `brief`, `output_paths`, active signals, and `skill_section`, then call `aether spawn-complete`.
+    4. Collect terminal surveyor results into a completion JSON file containing the original `colonize_manifest` and a `dispatches` array.
+    5. Run `AETHER_OUTPUT_MODE=json aether colonize-finalize --completion-file <file>` to let the runtime write survey artifacts, spawn-tree status, session, and colony state.
+  post_colonize: |
+    Close from `colonize-finalize` output only:
+    1. Summarize which surveyors actually ran and which survey files were written.
+    2. Route first to `/ant-plan`, keeping `aether plan` as the runtime source of truth beneath the wrapper.
 guardrails:
+  - "Do NOT run nested subprocess surveyors from Claude/OpenCode wrapper orchestration."
   - "Do not write colony state files, session files, or pheromone files by hand from this command spec."
+  - "Do not copy command wrappers into target repos; commands are published globally through the platform homes."
+  - "Do NOT parse visual output as authoritative state."
+  - "Do NOT run `aether colonize` without `--plan-only` from Claude/OpenCode wrapper orchestration unless the user explicitly asks for raw/no-orchestration."
   - "If docs and runtime disagree, runtime wins."

--- a/.claude/commands/ant/colonize.md
+++ b/.claude/commands/ant/colonize.md
@@ -1,14 +1,90 @@
 <!-- Generated from .aether/commands/colonize.yaml - DO NOT EDIT DIRECTLY -->
 ---
 name: ant-colonize
-description: "🗺️ Survey territory with 4 parallel scouts for comprehensive colony intelligence"
+description: "🗺️ Survey territory with visible platform Surveyor workers"
 ---
 
-You are the **Queen**. Dispatch Surveyor Ants through the runtime CLI.
+You are the **Queen**. The colony surveys through real wrapper-spawned Surveyor workers.
 
-Use the Go `aether` CLI as the source of truth.
+Use the Go `aether` CLI as the source of truth. The runtime owns final survey artifacts, spawn-tree status, session updates, and colony state. The wrapper owns only the visible platform worker ceremony.
 
-- Execute `AETHER_OUTPUT_MODE=visual aether colonize $ARGUMENTS` directly.
-- Do not bootstrap `COLONY_STATE.json` or survey files by hand from this command spec.
-- Do not reimplement surveyor spawning, stale-session handling, or survey verification here.
-- Report the CLI survey summary and any next-step routing directly.
+## Survey Manifest
+
+Ask the runtime for the authoritative survey manifest:
+
+```
+AETHER_OUTPUT_MODE=json aether colonize --plan-only $ARGUMENTS
+```
+
+Parse `result.colonize_manifest`. This manifest is the only source for worker names, castes, task IDs, agent names, briefs, output paths, skill sections, and finalizer contract.
+
+If the runtime returns `dispatch_mode: agent-delegate`, this is the expected hosted-agent path. Do not run nested subprocess surveyors. Dispatch the manifest workers through the current platform.
+
+If the runtime reports an existing survey, follow the runtime recovery guidance before spawning workers.
+
+## Wave Execution
+
+For each dispatch in `colonize_manifest.dispatches`:
+
+1. Run:
+   `AETHER_OUTPUT_MODE=json aether spawn-log --parent "Queen" --caste "{caste}" --name "{name}" --task "{task}" --depth 1`
+2. Spawn the matching platform agent using `subagent_type="{agent_name}"` or the platform equivalent.
+3. Use a concise agent description: `🗺️ Surveyor {name}: {task}`.
+4. Inject the dispatch `brief`, `output_paths`, active signals, `skill_section` when present, and exact task metadata.
+5. Require every surveyor to return a terminal structured result with: `name`, `caste`, `stage`, `wave`, `task_id`, `status`, `summary`, `files_created`, `files_modified`, `blockers`, and `duration`.
+6. After each worker returns, run:
+   `AETHER_OUTPUT_MODE=json aether spawn-complete --name "{name}" --status "{status}" --summary "{summary}"`
+
+Surveyors are independent read-only repo explorers except for their assigned survey outputs under `.aether/data/survey/`.
+
+## Completion Packet
+
+After all surveyors have terminal results, write a temporary completion JSON file outside `.aether/data/`:
+
+```json
+{
+  "colonize_manifest": {
+    "...": "the exact result.colonize_manifest object"
+  },
+  "dispatches": [
+    {
+      "name": "Map-12",
+      "caste": "surveyor-nest",
+      "stage": "survey",
+      "wave": 1,
+      "task_id": "survey-1",
+      "status": "completed",
+      "summary": "Mapped architecture and chamber layout.",
+      "files_created": [".aether/data/survey/BLUEPRINT.md", ".aether/data/survey/CHAMBERS.md"],
+      "files_modified": [],
+      "blockers": [],
+      "duration": 0
+    }
+  ]
+}
+```
+
+Then finalize through the runtime:
+
+```
+AETHER_OUTPUT_MODE=json aether colonize-finalize --completion-file <completion_file>
+```
+
+## After Colonize
+
+Branch strictly on `colonize-finalize` output:
+
+1. Summarize which surveyors ran and which survey files were written.
+2. Route first to `/ant-plan` or the runtime-surfaced next command.
+
+## Cross-Platform Drift Guard
+
+If you change colonize manifest handling, worker spawning, finalization, or closeout behavior here, update `.aether/commands/colonize.yaml`, both platform colonize wrappers, the Codex skill `aether-colony-build-cycle`, and `cmd/command_guide.go` in the same change. Verify `aether command-guide colonize --platform codex` still describes the matching Codex flow.
+
+## Guardrails
+
+- Do NOT run `aether colonize` without `--plan-only` from this wrapper unless the user explicitly asks for raw/no-orchestration.
+- Do NOT hand-edit `.aether/data/`, `COLONY_STATE.json`, `session.json`, or pheromone files.
+- Do NOT copy command wrappers into target repos; Aether commands are published globally.
+- Do NOT invent worker names, castes, task IDs, or outputs; use `colonize_manifest`.
+- If docs and runtime disagree, runtime wins.

--- a/.opencode/commands/ant/colonize.md
+++ b/.opencode/commands/ant/colonize.md
@@ -1,14 +1,90 @@
 <!-- Generated from .aether/commands/colonize.yaml - DO NOT EDIT DIRECTLY -->
 ---
 name: ant-colonize
-description: "🗺️ Survey territory with 4 parallel scouts for comprehensive colony intelligence"
+description: "🗺️ Survey territory with visible platform Surveyor workers"
 ---
 
-You are the **Queen**. Dispatch Surveyor Ants through the runtime CLI.
+You are the **Queen**. The colony surveys through real wrapper-spawned Surveyor workers.
 
-Use the Go `aether` CLI as the source of truth.
+Use the Go `aether` CLI as the source of truth. The runtime owns final survey artifacts, spawn-tree status, session updates, and colony state. The wrapper owns only the visible platform worker ceremony.
 
-- Execute `AETHER_OUTPUT_MODE=visual aether colonize $ARGUMENTS` directly.
-- Do not bootstrap `COLONY_STATE.json` or survey files by hand from this command spec.
-- Do not reimplement surveyor spawning, stale-session handling, or survey verification here.
-- Report the CLI survey summary and any next-step routing directly.
+## Survey Manifest
+
+Ask the runtime for the authoritative survey manifest:
+
+```
+AETHER_OUTPUT_MODE=json aether colonize --plan-only $ARGUMENTS
+```
+
+Parse `result.colonize_manifest`. This manifest is the only source for worker names, castes, task IDs, agent names, briefs, output paths, skill sections, and finalizer contract.
+
+If the runtime returns `dispatch_mode: agent-delegate`, this is the expected hosted-agent path. Do not run nested subprocess surveyors. Dispatch the manifest workers through the current platform.
+
+If the runtime reports an existing survey, follow the runtime recovery guidance before spawning workers.
+
+## Wave Execution
+
+For each dispatch in `colonize_manifest.dispatches`:
+
+1. Run:
+   `AETHER_OUTPUT_MODE=json aether spawn-log --parent "Queen" --caste "{caste}" --name "{name}" --task "{task}" --depth 1`
+2. Spawn the matching platform agent using `subagent_type="{agent_name}"` or the platform equivalent.
+3. Use a concise agent description: `🗺️ Surveyor {name}: {task}`.
+4. Inject the dispatch `brief`, `output_paths`, active signals, `skill_section` when present, and exact task metadata.
+5. Require every surveyor to return a terminal structured result with: `name`, `caste`, `stage`, `wave`, `task_id`, `status`, `summary`, `files_created`, `files_modified`, `blockers`, and `duration`.
+6. After each worker returns, run:
+   `AETHER_OUTPUT_MODE=json aether spawn-complete --name "{name}" --status "{status}" --summary "{summary}"`
+
+Surveyors are independent read-only repo explorers except for their assigned survey outputs under `.aether/data/survey/`.
+
+## Completion Packet
+
+After all surveyors have terminal results, write a temporary completion JSON file outside `.aether/data/`:
+
+```json
+{
+  "colonize_manifest": {
+    "...": "the exact result.colonize_manifest object"
+  },
+  "dispatches": [
+    {
+      "name": "Map-12",
+      "caste": "surveyor-nest",
+      "stage": "survey",
+      "wave": 1,
+      "task_id": "survey-1",
+      "status": "completed",
+      "summary": "Mapped architecture and chamber layout.",
+      "files_created": [".aether/data/survey/BLUEPRINT.md", ".aether/data/survey/CHAMBERS.md"],
+      "files_modified": [],
+      "blockers": [],
+      "duration": 0
+    }
+  ]
+}
+```
+
+Then finalize through the runtime:
+
+```
+AETHER_OUTPUT_MODE=json aether colonize-finalize --completion-file <completion_file>
+```
+
+## After Colonize
+
+Branch strictly on `colonize-finalize` output:
+
+1. Summarize which surveyors ran and which survey files were written.
+2. Route first to `/ant-plan` or the runtime-surfaced next command.
+
+## Cross-Platform Drift Guard
+
+If you change colonize manifest handling, worker spawning, finalization, or closeout behavior here, update `.aether/commands/colonize.yaml`, both platform colonize wrappers, the Codex skill `aether-colony-build-cycle`, and `cmd/command_guide.go` in the same change. Verify `aether command-guide colonize --platform codex` still describes the matching Codex flow.
+
+## Guardrails
+
+- Do NOT run `aether colonize` without `--plan-only` from this wrapper unless the user explicitly asks for raw/no-orchestration.
+- Do NOT hand-edit `.aether/data/`, `COLONY_STATE.json`, `session.json`, or pheromone files.
+- Do NOT copy command wrappers into target repos; Aether commands are published globally.
+- Do NOT invent worker names, castes, task IDs, or outputs; use `colonize_manifest`.
+- If docs and runtime disagree, runtime wins.

--- a/cmd/codex_colonize.go
+++ b/cmd/codex_colonize.go
@@ -17,14 +17,24 @@ import (
 )
 
 type codexSurveyorDispatch struct {
-	Caste    string   `json:"caste"`
-	Name     string   `json:"name"`
-	Task     string   `json:"task"`
-	Outputs  []string `json:"outputs"`
-	Status   string   `json:"status"`
-	Summary  string   `json:"summary,omitempty"`
-	Duration float64  `json:"duration,omitempty"` // Wall-clock seconds (0 = not measured)
-	Claimed  []string `json:"-"`
+	Stage         string   `json:"stage,omitempty"`
+	Wave          int      `json:"wave,omitempty"`
+	Caste         string   `json:"caste"`
+	Name          string   `json:"name"`
+	Task          string   `json:"task"`
+	TaskID        string   `json:"task_id,omitempty"`
+	AgentName     string   `json:"agent_name,omitempty"`
+	Brief         string   `json:"brief,omitempty"`
+	Outputs       []string `json:"outputs"`
+	OutputPaths   []string `json:"output_paths,omitempty"`
+	Status        string   `json:"status"`
+	Summary       string   `json:"summary,omitempty"`
+	Blockers      []string `json:"blockers,omitempty"`
+	Duration      float64  `json:"duration,omitempty"` // Wall-clock seconds (0 = not measured)
+	FilesCreated  []string `json:"files_created,omitempty"`
+	FilesModified []string `json:"files_modified,omitempty"`
+	SkillSection  string   `json:"skill_section,omitempty"`
+	Claimed       []string `json:"-"`
 }
 
 type codexWorkspaceFacts struct {
@@ -51,6 +61,29 @@ type codexWorkspaceFacts struct {
 type codexColonizeOptions struct {
 	ForceResurvey bool
 	WorkerTimeout time.Duration
+	PlanOnly      bool
+}
+
+type codexColonizeManifest struct {
+	Workflow             string                           `json:"workflow"`
+	DispatchMode         string                           `json:"dispatch_mode"`
+	RequiresFinalizer    bool                             `json:"requires_finalizer"`
+	GeneratedAt          string                           `json:"generated_at"`
+	Root                 string                           `json:"root"`
+	DetectedType         string                           `json:"detected_type"`
+	Languages            []string                         `json:"languages"`
+	Frameworks           []string                         `json:"frameworks"`
+	Domains              []string                         `json:"domains"`
+	EntryPoints          []string                         `json:"entry_points"`
+	KeyDirs              []string                         `json:"key_dirs"`
+	ExistingSurvey       bool                             `json:"existing_survey"`
+	ForceResurvey        bool                             `json:"force_resurvey"`
+	WorkerTimeoutSeconds int                              `json:"worker_timeout_seconds"`
+	DispatchContract     map[string]interface{}           `json:"dispatch_contract"`
+	Dispatches           []codexSurveyorDispatch          `json:"dispatches"`
+	Snapshots            map[string]codexArtifactSnapshot `json:"snapshots,omitempty"`
+	FinalizerCommand     string                           `json:"finalizer_command"`
+	Stats                map[string]interface{}           `json:"stats,omitempty"`
 }
 
 // logActivity appends an entry to the activity log. It is a no-op if the
@@ -74,6 +107,10 @@ func runCodexColonize(root string, force bool) (map[string]interface{}, error) {
 func runCodexColonizeWithOptions(root string, opts codexColonizeOptions) (map[string]interface{}, error) {
 	if store == nil {
 		return nil, fmt.Errorf("no store initialized")
+	}
+
+	if opts.PlanOnly || codex.ShouldUseAgentDelegatePath() {
+		return runCodexColonizePlanOnly(root, opts)
 	}
 
 	facts, err := surveyWorkspace(root)
@@ -177,23 +214,7 @@ func runCodexColonizeWithOptions(root string, opts codexColonizeOptions) (map[st
 	}
 	updateSessionSummary("colonize", "aether plan", fmt.Sprintf("Territory surveyed (%d documents)", len(surveyFiles)))
 
-	dispatchMaps := make([]map[string]interface{}, 0, len(dispatches))
-	for _, dispatch := range dispatches {
-		entry := map[string]interface{}{
-			"caste":   dispatch.Caste,
-			"name":    dispatch.Name,
-			"task":    dispatch.Task,
-			"outputs": dispatch.Outputs,
-			"status":  dispatch.Status,
-		}
-		if summary := strings.TrimSpace(dispatch.Summary); summary != "" {
-			entry["summary"] = summary
-		}
-		if dispatch.Duration > 0 {
-			entry["duration"] = dispatch.Duration
-		}
-		dispatchMaps = append(dispatchMaps, entry)
-	}
+	dispatchMaps := surveyorDispatchMaps(dispatches)
 
 	result := map[string]interface{}{
 		"root":               facts.Root,
@@ -238,6 +259,49 @@ func runCodexColonizeWithOptions(root string, opts codexColonizeOptions) (map[st
 	return result, nil
 }
 
+func surveyorDispatchMaps(dispatches []codexSurveyorDispatch) []map[string]interface{} {
+	dispatchMaps := make([]map[string]interface{}, 0, len(dispatches))
+	for _, dispatch := range dispatches {
+		entry := map[string]interface{}{
+			"stage":      dispatch.Stage,
+			"wave":       dispatch.Wave,
+			"caste":      dispatch.Caste,
+			"name":       dispatch.Name,
+			"task":       dispatch.Task,
+			"task_id":    dispatch.TaskID,
+			"agent_name": dispatch.AgentName,
+			"outputs":    dispatch.Outputs,
+			"status":     dispatch.Status,
+		}
+		if len(dispatch.OutputPaths) > 0 {
+			entry["output_paths"] = dispatch.OutputPaths
+		}
+		if brief := strings.TrimSpace(dispatch.Brief); brief != "" {
+			entry["brief"] = brief
+		}
+		if skillSection := strings.TrimSpace(dispatch.SkillSection); skillSection != "" {
+			entry["skill_section"] = skillSection
+		}
+		if summary := strings.TrimSpace(dispatch.Summary); summary != "" {
+			entry["summary"] = summary
+		}
+		if len(dispatch.Blockers) > 0 {
+			entry["blockers"] = dispatch.Blockers
+		}
+		if dispatch.Duration > 0 {
+			entry["duration"] = dispatch.Duration
+		}
+		if len(dispatch.FilesCreated) > 0 {
+			entry["files_created"] = dispatch.FilesCreated
+		}
+		if len(dispatch.FilesModified) > 0 {
+			entry["files_modified"] = dispatch.FilesModified
+		}
+		dispatchMaps = append(dispatchMaps, entry)
+	}
+	return dispatchMaps
+}
+
 func runColonizeCodebaseGraph(root string) (*codegraph.Stats, string) {
 	stats, err := runCodebaseScanFromColonize(root, nil)
 	if err != nil {
@@ -248,6 +312,106 @@ func runColonizeCodebaseGraph(root string) (*codegraph.Stats, string) {
 		logActivity("colonize", fmt.Sprintf("codebase graph scanned %d files, %d edges", stats.FilesScanned, stats.EdgesFound))
 	}
 	return stats, ""
+}
+
+func runCodexColonizePlanOnly(root string, opts codexColonizeOptions) (map[string]interface{}, error) {
+	if store == nil {
+		return nil, fmt.Errorf("no store initialized")
+	}
+
+	facts, err := surveyWorkspace(root)
+	if err != nil {
+		return nil, err
+	}
+
+	surveyDir := filepath.Join(store.BasePath(), "survey")
+	existingSurvey := surveyDocsExist(surveyDir)
+	if existingSurvey && !opts.ForceResurvey {
+		return nil, fmt.Errorf("existing territory survey found; rerun with `aether colonize --force-resurvey` to refresh it")
+	}
+
+	dispatchMode := "plan-only"
+	status := "plan-only"
+	next := "dispatch host surveyor agents, then run `aether colonize-finalize --completion-file <file>`"
+	if codex.ShouldUseAgentDelegatePath() {
+		dispatchMode = "agent-delegate"
+		status = "agent-delegate"
+	}
+
+	manifest := buildCodexColonizeManifest(root, facts, opts, dispatchMode, existingSurvey, snapshotRelativeFiles(root, filepath.ToSlash(filepath.Join(".aether", "data", "survey"))))
+	dispatchMaps := surveyorDispatchMaps(manifest.Dispatches)
+	result := map[string]interface{}{
+		"status":                status,
+		"root":                  facts.Root,
+		"detected_type":         facts.DetectedType,
+		"languages":             facts.Languages,
+		"frameworks":            facts.Frameworks,
+		"domains":               facts.Domains,
+		"entry_points":          facts.EntryPoints,
+		"key_dirs":              facts.TopLevelDirs,
+		"existing_survey":       existingSurvey,
+		"force_resurvey":        opts.ForceResurvey,
+		"dispatch_mode":         dispatchMode,
+		"dispatch_contract":     manifest.DispatchContract,
+		"colonize_manifest":     manifest,
+		"dispatches":            dispatchMaps,
+		"surveyors":             dispatchMaps,
+		"requires_finalizer":    true,
+		"finalizer_command":     manifest.FinalizerCommand,
+		"execution_owner":       "host-platform",
+		"agent_delegate":        dispatchMode == "agent-delegate",
+		"agent_delegate_reason": strings.TrimSpace(codex.AgentDelegateFallbackReason()),
+		"stats":                 manifest.Stats,
+		"next":                  next,
+	}
+	return result, nil
+}
+
+func buildCodexColonizeManifest(root string, facts codexWorkspaceFacts, opts codexColonizeOptions, dispatchMode string, existingSurvey bool, snapshots map[string]codexArtifactSnapshot) codexColonizeManifest {
+	workerTimeout := effectiveSurveyorDispatchTimeout(opts.WorkerTimeout)
+	dispatches := plannedSurveyors(root)
+	for i := range dispatches {
+		dispatches[i].Stage = "survey"
+		dispatches[i].Wave = 1
+		if dispatches[i].TaskID == "" {
+			dispatches[i].TaskID = fmt.Sprintf("survey-%d", i)
+		}
+		outputPaths := make([]string, 0, len(dispatches[i].Outputs))
+		for _, output := range dispatches[i].Outputs {
+			outputPaths = append(outputPaths, filepath.ToSlash(filepath.Join(".aether", "data", "survey", output)))
+		}
+		dispatches[i].OutputPaths = outputPaths
+		if dispatches[i].Brief == "" {
+			dispatches[i].Brief = fmt.Sprintf("Survey task: %s\n\nWrite these survey outputs in the repo: %s\n\nSurvey the territory at %s", dispatches[i].Task, strings.Join(outputPaths, ", "), root)
+		}
+		if dispatches[i].SkillSection == "" {
+			dispatches[i].SkillSection = resolveSkillSectionForWorkflow("colonize", dispatches[i].Caste, dispatches[i].Task)
+		}
+	}
+	return codexColonizeManifest{
+		Workflow:             "colonize",
+		DispatchMode:         dispatchMode,
+		RequiresFinalizer:    true,
+		GeneratedAt:          time.Now().UTC().Format(time.RFC3339),
+		Root:                 facts.Root,
+		DetectedType:         facts.DetectedType,
+		Languages:            facts.Languages,
+		Frameworks:           facts.Frameworks,
+		Domains:              facts.Domains,
+		EntryPoints:          facts.EntryPoints,
+		KeyDirs:              facts.TopLevelDirs,
+		ExistingSurvey:       existingSurvey,
+		ForceResurvey:        opts.ForceResurvey,
+		WorkerTimeoutSeconds: int(workerTimeout / time.Second),
+		DispatchContract:     surveyDispatchContractWithTimeout(opts.WorkerTimeout),
+		Dispatches:           dispatches,
+		Snapshots:            snapshots,
+		FinalizerCommand:     "AETHER_OUTPUT_MODE=json aether colonize-finalize --completion-file <file>",
+		Stats: map[string]interface{}{
+			"files":       facts.FileCount,
+			"directories": facts.DirectoryCount,
+		},
+	}
 }
 
 func surveyWorkspace(root string) (codexWorkspaceFacts, error) {
@@ -410,32 +574,48 @@ func surveyWorkspace(root string) (codexWorkspaceFacts, error) {
 func plannedSurveyors(root string) []codexSurveyorDispatch {
 	return []codexSurveyorDispatch{
 		{
-			Caste:   "surveyor-provisions",
-			Name:    deterministicAntName("surveyor", root+"|provisions"),
-			Task:    "Map provisions and external trails",
-			Outputs: []string{"PROVISIONS.md", "TRAILS.md"},
-			Status:  "spawned",
+			Stage:     "survey",
+			Wave:      1,
+			Caste:     "surveyor-provisions",
+			Name:      deterministicAntName("surveyor", root+"|provisions"),
+			Task:      "Map provisions and external trails",
+			TaskID:    "survey-0",
+			AgentName: "aether-surveyor-provisions",
+			Outputs:   []string{"PROVISIONS.md", "TRAILS.md"},
+			Status:    "spawned",
 		},
 		{
-			Caste:   "surveyor-nest",
-			Name:    deterministicAntName("surveyor", root+"|nest"),
-			Task:    "Map architecture and chamber layout",
-			Outputs: []string{"BLUEPRINT.md", "CHAMBERS.md"},
-			Status:  "spawned",
+			Stage:     "survey",
+			Wave:      1,
+			Caste:     "surveyor-nest",
+			Name:      deterministicAntName("surveyor", root+"|nest"),
+			Task:      "Map architecture and chamber layout",
+			TaskID:    "survey-1",
+			AgentName: "aether-surveyor-nest",
+			Outputs:   []string{"BLUEPRINT.md", "CHAMBERS.md"},
+			Status:    "spawned",
 		},
 		{
-			Caste:   "surveyor-disciplines",
-			Name:    deterministicAntName("surveyor", root+"|disciplines"),
-			Task:    "Map disciplines and sentinel protocols",
-			Outputs: []string{"DISCIPLINES.md", "SENTINEL-PROTOCOLS.md"},
-			Status:  "spawned",
+			Stage:     "survey",
+			Wave:      1,
+			Caste:     "surveyor-disciplines",
+			Name:      deterministicAntName("surveyor", root+"|disciplines"),
+			Task:      "Map disciplines and sentinel protocols",
+			TaskID:    "survey-2",
+			AgentName: "aether-surveyor-disciplines",
+			Outputs:   []string{"DISCIPLINES.md", "SENTINEL-PROTOCOLS.md"},
+			Status:    "spawned",
 		},
 		{
-			Caste:   "surveyor-pathogens",
-			Name:    deterministicAntName("surveyor", root+"|pathogens"),
-			Task:    "Identify pathogens and fragile boundaries",
-			Outputs: []string{"PATHOGENS.md"},
-			Status:  "spawned",
+			Stage:     "survey",
+			Wave:      1,
+			Caste:     "surveyor-pathogens",
+			Name:      deterministicAntName("surveyor", root+"|pathogens"),
+			Task:      "Identify pathogens and fragile boundaries",
+			TaskID:    "survey-3",
+			AgentName: "aether-surveyor-pathogens",
+			Outputs:   []string{"PATHOGENS.md"},
+			Status:    "spawned",
 		},
 	}
 }
@@ -537,11 +717,15 @@ func convertDispatchResults(results []codex.DispatchResult, specs []surveyorSpec
 		name := deterministicAntName("surveyor", seed)
 
 		d := codexSurveyorDispatch{
-			Caste:   spec.Caste,
-			Name:    name,
-			Task:    spec.Task,
-			Outputs: spec.Outputs,
-			Status:  "spawned",
+			Stage:     "survey",
+			Wave:      1,
+			Caste:     spec.Caste,
+			Name:      name,
+			Task:      spec.Task,
+			TaskID:    fmt.Sprintf("survey-%d", i),
+			AgentName: fmt.Sprintf("aether-surveyor-%s", spec.AgentSuffix),
+			Outputs:   spec.Outputs,
+			Status:    "spawned",
 		}
 
 		if i < len(results) {
@@ -553,11 +737,14 @@ func convertDispatchResults(results []codex.DispatchResult, specs []surveyorSpec
 			d.Status = normalizeRuntimeDispatchStatus(r.Status)
 			if r.WorkerResult != nil {
 				d.Duration = r.WorkerResult.Duration.Seconds()
-				d.Claimed = append(d.Claimed, r.WorkerResult.FilesCreated...)
-				d.Claimed = append(d.Claimed, r.WorkerResult.FilesModified...)
+				d.FilesCreated = append(d.FilesCreated, r.WorkerResult.FilesCreated...)
+				d.FilesModified = append(d.FilesModified, r.WorkerResult.FilesModified...)
+				d.Claimed = append(d.Claimed, d.FilesCreated...)
+				d.Claimed = append(d.Claimed, d.FilesModified...)
 				d.Claimed = uniqueSortedStrings(d.Claimed)
 				d.Summary = strings.TrimSpace(r.WorkerResult.Summary)
 				if d.Summary == "" && len(r.WorkerResult.Blockers) > 0 {
+					d.Blockers = append(d.Blockers, r.WorkerResult.Blockers...)
 					d.Summary = strings.Join(r.WorkerResult.Blockers, "; ")
 				}
 			}

--- a/cmd/codex_colonize_finalize.go
+++ b/cmd/codex_colonize_finalize.go
@@ -1,0 +1,307 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/calcosmic/Aether/pkg/agent"
+	"github.com/spf13/cobra"
+)
+
+type codexExternalColonizeCompletion struct {
+	ColonizeManifest *codexColonizeManifest  `json:"colonize_manifest,omitempty"`
+	SurveyManifest   *codexColonizeManifest  `json:"survey_manifest,omitempty"`
+	Manifest         *codexColonizeManifest  `json:"manifest,omitempty"`
+	Dispatches       []codexSurveyorDispatch `json:"dispatches,omitempty"`
+	Results          []codexSurveyorDispatch `json:"results,omitempty"`
+	Workers          []codexSurveyorDispatch `json:"workers,omitempty"`
+}
+
+var colonizeFinalizeCmd = &cobra.Command{
+	Use:   "colonize-finalize",
+	Short: "Record externally spawned surveyor workers as the territory survey",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		completionPath, _ := cmd.Flags().GetString("completion-file")
+		completion, err := loadExternalColonizeCompletion(completionPath)
+		if err != nil {
+			outputError(1, err.Error(), nil)
+			return nil
+		}
+		result, err := runCodexColonizeFinalize(skillWorkspaceRoot(), completion)
+		if err != nil {
+			outputError(1, err.Error(), nil)
+			return nil
+		}
+		outputWorkflow(result, renderColonizeVisual(result))
+		return nil
+	},
+}
+
+func loadExternalColonizeCompletion(path string) (codexExternalColonizeCompletion, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return codexExternalColonizeCompletion{}, fmt.Errorf("flag --completion-file is required")
+	}
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return codexExternalColonizeCompletion{}, fmt.Errorf("read completion file: %w", err)
+	}
+
+	var completion codexExternalColonizeCompletion
+	if err := json.Unmarshal(data, &completion); err != nil {
+		return codexExternalColonizeCompletion{}, fmt.Errorf("parse completion file: %w", err)
+	}
+	if completion.activeManifest() != nil {
+		return completion, nil
+	}
+
+	var envelope struct {
+		Result codexExternalColonizeCompletion `json:"result"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return codexExternalColonizeCompletion{}, fmt.Errorf("parse completion envelope: %w", err)
+	}
+	if envelope.Result.activeManifest() == nil {
+		return codexExternalColonizeCompletion{}, fmt.Errorf("completion file must include colonize_manifest")
+	}
+	return envelope.Result, nil
+}
+
+func (c codexExternalColonizeCompletion) activeManifest() *codexColonizeManifest {
+	if c.ColonizeManifest != nil {
+		return c.ColonizeManifest
+	}
+	if c.SurveyManifest != nil {
+		return c.SurveyManifest
+	}
+	return c.Manifest
+}
+
+func (c codexExternalColonizeCompletion) workerResults() []codexSurveyorDispatch {
+	results := make([]codexSurveyorDispatch, 0, len(c.Dispatches)+len(c.Results)+len(c.Workers))
+	results = append(results, c.Dispatches...)
+	results = append(results, c.Results...)
+	results = append(results, c.Workers...)
+	return results
+}
+
+func runCodexColonizeFinalize(root string, completion codexExternalColonizeCompletion) (map[string]interface{}, error) {
+	if store == nil {
+		return nil, fmt.Errorf("no store initialized")
+	}
+	manifest := completion.activeManifest()
+	if manifest == nil {
+		return nil, fmt.Errorf("completion file must include colonize_manifest")
+	}
+	if (manifest.DispatchMode != "plan-only" && manifest.DispatchMode != "agent-delegate") || !manifest.RequiresFinalizer {
+		return nil, fmt.Errorf("colonize_manifest must come from `aether colonize --plan-only` or an agent-delegate colonize response")
+	}
+	if len(manifest.Dispatches) == 0 {
+		return nil, fmt.Errorf("colonize_manifest contains no dispatches")
+	}
+	if strings.TrimSpace(manifest.Root) != "" && !sameCleanPath(manifest.Root, root) {
+		return nil, fmt.Errorf("colonize_manifest root does not match current workspace (manifest=%s current=%s)", manifest.Root, root)
+	}
+
+	facts, err := surveyWorkspace(root)
+	if err != nil {
+		return nil, err
+	}
+
+	surveyDir := filepath.Join(store.BasePath(), "survey")
+	if surveyDocsExist(surveyDir) && !manifest.ForceResurvey && !manifest.ExistingSurvey {
+		return nil, fmt.Errorf("existing territory survey found; rerun `aether colonize --plan-only --force-resurvey` before finalizing a replacement")
+	}
+	if err := os.MkdirAll(surveyDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create survey directory: %w", err)
+	}
+
+	now := time.Now().UTC()
+	runHandle, err := beginRuntimeSpawnRun("colonize", now)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize colonize run: %w", err)
+	}
+	runStatus := "failed"
+	defer func() {
+		finishRuntimeSpawnRun(runHandle, runStatus, time.Now().UTC())
+	}()
+
+	dispatches, err := mergeExternalSurveyResults(*manifest, completion.workerResults())
+	if err != nil {
+		return nil, err
+	}
+	if err := recordExternalSurveySpawnTree(dispatches); err != nil {
+		return nil, err
+	}
+
+	surveyFiles, preservedWorkerArtifacts, err := writeSurveyArtifacts(root, surveyDir, facts, dispatches, manifest.Snapshots)
+	if err != nil {
+		return nil, err
+	}
+	artifactSource := "runtime-synthesis"
+	if preservedWorkerArtifacts > 0 {
+		artifactSource = "external-task"
+	}
+	if err := writeSurveyCompatibilityJSON(surveyDir, facts); err != nil {
+		return nil, err
+	}
+	codegraphStats, codegraphWarning := runColonizeCodebaseGraph(root)
+
+	surveyedAt := now.Format(time.RFC3339)
+	if err := updateSurveyState(surveyedAt, len(surveyFiles)); err != nil {
+		return nil, err
+	}
+	emitColonizeCeremonyDispatchSequence("aether-colonize-finalize", dispatches)
+	updateSessionSummary("colonize-finalize", "aether plan", fmt.Sprintf("Territory surveyed by external workers (%d documents)", len(surveyFiles)))
+	runStatus = summarizeRunStatus(surveyorStatuses(dispatches)...)
+
+	result := map[string]interface{}{
+		"root":               facts.Root,
+		"detected_type":      facts.DetectedType,
+		"languages":          facts.Languages,
+		"frameworks":         facts.Frameworks,
+		"domains":            facts.Domains,
+		"entry_points":       facts.EntryPoints,
+		"key_dirs":           facts.TopLevelDirs,
+		"survey_dir":         surveyDir,
+		"survey_files":       surveyFiles,
+		"surveyors":          surveyorDispatchMaps(dispatches),
+		"dispatches":         surveyorDispatchMaps(dispatches),
+		"existing_survey":    manifest.ExistingSurvey,
+		"force_resurvey":     manifest.ForceResurvey,
+		"territory_surveyed": surveyedAt,
+		"dispatch_mode":      "external-task",
+		"dispatch_contract":  manifest.DispatchContract,
+		"artifact_source":    artifactSource,
+		"survey_warning":     "",
+		"stats": map[string]interface{}{
+			"files":       facts.FileCount,
+			"directories": facts.DirectoryCount,
+		},
+		"next": "aether plan",
+	}
+	if codegraphStats != nil {
+		result["codebase_graph"] = map[string]interface{}{
+			"files_scanned": codegraphStats.FilesScanned,
+			"edges_found":   codegraphStats.EdgesFound,
+			"languages":     codegraphStats.Languages,
+			"output":        "codebase-graph.json",
+		}
+	}
+	if codegraphWarning != "" {
+		result["codebase_graph_warning"] = codegraphWarning
+	}
+	return result, nil
+}
+
+func sameCleanPath(a, b string) bool {
+	aAbs, aErr := filepath.Abs(filepath.Clean(strings.TrimSpace(a)))
+	bAbs, bErr := filepath.Abs(filepath.Clean(strings.TrimSpace(b)))
+	if aErr != nil || bErr != nil {
+		return filepath.Clean(a) == filepath.Clean(b)
+	}
+	if aReal, err := filepath.EvalSymlinks(aAbs); err == nil {
+		aAbs = aReal
+	}
+	if bReal, err := filepath.EvalSymlinks(bAbs); err == nil {
+		bAbs = bReal
+	}
+	return aAbs == bAbs
+}
+
+func mergeExternalSurveyResults(manifest codexColonizeManifest, results []codexSurveyorDispatch) ([]codexSurveyorDispatch, error) {
+	resultByName := make(map[string]codexSurveyorDispatch, len(results))
+	resultByTaskID := make(map[string]codexSurveyorDispatch, len(results))
+	for _, result := range results {
+		if name := strings.TrimSpace(result.Name); name != "" {
+			resultByName[name] = result
+		}
+		if taskID := strings.TrimSpace(result.TaskID); taskID != "" {
+			resultByTaskID[taskID] = result
+		}
+	}
+
+	merged := make([]codexSurveyorDispatch, 0, len(manifest.Dispatches))
+	for _, planned := range manifest.Dispatches {
+		result, ok := resultByName[strings.TrimSpace(planned.Name)]
+		if !ok && strings.TrimSpace(planned.TaskID) != "" {
+			result, ok = resultByTaskID[strings.TrimSpace(planned.TaskID)]
+		}
+		if !ok {
+			return nil, fmt.Errorf("missing external surveyor result for %s", planned.Name)
+		}
+		status := normalizeRuntimeDispatchStatus(result.Status)
+		if status == "" || status == "spawned" {
+			status = "completed"
+		}
+		if status != "completed" && status != "passed" && status != "code_written" {
+			summary := strings.TrimSpace(result.Summary)
+			if summary == "" && len(result.Blockers) > 0 {
+				summary = strings.Join(result.Blockers, "; ")
+			}
+			if summary == "" {
+				summary = "no summary provided"
+			}
+			return nil, fmt.Errorf("surveyor %s did not complete: %s (%s)", planned.Name, status, summary)
+		}
+
+		planned.Status = "completed"
+		if strings.TrimSpace(result.Name) != "" {
+			planned.Name = strings.TrimSpace(result.Name)
+		}
+		planned.Summary = strings.TrimSpace(result.Summary)
+		planned.Blockers = append([]string{}, result.Blockers...)
+		planned.Duration = result.Duration
+		planned.FilesCreated = append([]string{}, result.FilesCreated...)
+		planned.FilesModified = append([]string{}, result.FilesModified...)
+		planned.Claimed = uniqueSortedStrings(append(append([]string{}, planned.FilesCreated...), planned.FilesModified...))
+		if len(planned.Claimed) == 0 {
+			claimed := make([]string, 0, len(planned.OutputPaths))
+			for _, outputPath := range planned.OutputPaths {
+				if _, err := os.Stat(filepath.Join(manifest.Root, filepath.FromSlash(outputPath))); err == nil {
+					claimed = append(claimed, outputPath)
+				}
+			}
+			planned.Claimed = uniqueSortedStrings(claimed)
+		}
+		merged = append(merged, planned)
+	}
+	return merged, nil
+}
+
+func recordExternalSurveySpawnTree(dispatches []codexSurveyorDispatch) error {
+	spawnTree := agent.NewSpawnTree(store, "spawn-tree.txt")
+	for _, dispatch := range dispatches {
+		if err := spawnTree.RecordSpawn("Queen", "surveyor", dispatch.Name, dispatch.Task, 1); err != nil {
+			return fmt.Errorf("failed to record surveyor spawn: %w", err)
+		}
+		summary := strings.TrimSpace(dispatch.Summary)
+		if summary == "" {
+			summary = strings.Join(dispatch.Outputs, ", ")
+		}
+		if err := spawnTree.UpdateStatus(dispatch.Name, dispatch.Status, summary); err != nil {
+			return fmt.Errorf("failed to update surveyor completion: %w", err)
+		}
+	}
+	return nil
+}
+
+func surveyorStatuses(dispatches []codexSurveyorDispatch) []string {
+	statuses := make([]string, 0, len(dispatches))
+	for _, dispatch := range dispatches {
+		statuses = append(statuses, dispatch.Status)
+	}
+	return statuses
+}

--- a/cmd/codex_colonize_test.go
+++ b/cmd/codex_colonize_test.go
@@ -234,6 +234,131 @@ func TestColonizeIncludesDispatchContract(t *testing.T) {
 	}
 }
 
+func TestColonizePlanOnlyRequiresFinalizerAndDoesNotWriteSurvey(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+	t.Setenv("AETHER_OUTPUT_MODE", "json")
+
+	dataDir := setupBuildFlowTest(t)
+	root := filepath.Dir(filepath.Dir(dataDir))
+	withWorkingDir(t, root)
+
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/aether-colonize-plan-only-test\n\ngo 1.24\n"), 0644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	goal := "Survey with host-visible workers"
+	createTestColonyState(t, dataDir, colony.ColonyState{
+		Version: "3.0",
+		Goal:    &goal,
+		State:   colony.StateREADY,
+		Plan:    colony.Plan{Phases: []colony.Phase{}},
+	})
+
+	rootCmd.SetArgs([]string{"colonize", "--plan-only"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("colonize --plan-only returned error: %v", err)
+	}
+
+	env := parseEnvelope(t, stdout.(*bytes.Buffer).String())
+	result := env["result"].(map[string]interface{})
+	if got := result["dispatch_mode"]; got != "plan-only" {
+		t.Fatalf("dispatch_mode = %v, want plan-only", got)
+	}
+	if got, _ := result["requires_finalizer"].(bool); !got {
+		t.Fatalf("requires_finalizer = %v, want true", result["requires_finalizer"])
+	}
+	manifest := result["colonize_manifest"].(map[string]interface{})
+	if got := manifest["finalizer_command"]; !strings.Contains(stringValue(got), "colonize-finalize") {
+		t.Fatalf("finalizer_command = %v", got)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "survey", "PROVISIONS.md")); !os.IsNotExist(err) {
+		t.Fatalf("plan-only should not write survey artifacts, stat err=%v", err)
+	}
+	var state colony.ColonyState
+	if err := store.LoadJSON("COLONY_STATE.json", &state); err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if state.TerritorySurveyed != nil {
+		t.Fatalf("plan-only mutated TerritorySurveyed: %v", *state.TerritorySurveyed)
+	}
+}
+
+func TestColonizeFinalizeRecordsExternalSurveyors(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+	t.Setenv("AETHER_OUTPUT_MODE", "json")
+
+	dataDir := setupBuildFlowTest(t)
+	root := filepath.Dir(filepath.Dir(dataDir))
+	withWorkingDir(t, root)
+
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/aether-colonize-finalize-test\n\ngo 1.24\n"), 0644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	goal := "Survey with external host workers"
+	createTestColonyState(t, dataDir, colony.ColonyState{
+		Version: "3.0",
+		Goal:    &goal,
+		State:   colony.StateREADY,
+		Plan:    colony.Plan{Phases: []colony.Phase{}},
+	})
+
+	result, err := runCodexColonizePlanOnly(root, codexColonizeOptions{PlanOnly: true})
+	if err != nil {
+		t.Fatalf("runCodexColonizePlanOnly: %v", err)
+	}
+	manifest := result["colonize_manifest"].(codexColonizeManifest)
+	dispatches := make([]codexSurveyorDispatch, 0, len(manifest.Dispatches))
+	for _, dispatch := range manifest.Dispatches {
+		dispatch.Status = "completed"
+		dispatch.Summary = "survey complete"
+		dispatches = append(dispatches, dispatch)
+	}
+
+	completionPath := filepath.Join(t.TempDir(), "colonize-completion.json")
+	data, err := json.Marshal(map[string]interface{}{
+		"colonize_manifest": manifest,
+		"dispatches":        dispatches,
+	})
+	if err != nil {
+		t.Fatalf("marshal completion: %v", err)
+	}
+	if err := os.WriteFile(completionPath, data, 0644); err != nil {
+		t.Fatalf("write completion: %v", err)
+	}
+
+	resetRootCmd(t)
+	t.Setenv("AETHER_OUTPUT_MODE", "json")
+	stdout = &bytes.Buffer{}
+	var errBuf bytes.Buffer
+	stderr = &errBuf
+	rootCmd.SetArgs([]string{"colonize-finalize", "--completion-file", completionPath})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("colonize-finalize returned error: %v", err)
+	}
+	if strings.TrimSpace(stdout.(*bytes.Buffer).String()) == "" {
+		t.Fatalf("colonize-finalize wrote no stdout; stderr=%s", errBuf.String())
+	}
+
+	env := parseEnvelope(t, stdout.(*bytes.Buffer).String())
+	finalizeResult := env["result"].(map[string]interface{})
+	if got := finalizeResult["dispatch_mode"]; got != "external-task" {
+		t.Fatalf("dispatch_mode = %v, want external-task", got)
+	}
+	for _, name := range []string{"PROVISIONS.md", "TRAILS.md", "BLUEPRINT.md", "CHAMBERS.md", "DISCIPLINES.md", "SENTINEL-PROTOCOLS.md", "PATHOGENS.md"} {
+		if _, err := os.Stat(filepath.Join(dataDir, "survey", name)); err != nil {
+			t.Fatalf("expected survey file %s: %v", name, err)
+		}
+	}
+	var state colony.ColonyState
+	if err := store.LoadJSON("COLONY_STATE.json", &state); err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if state.TerritorySurveyed == nil || *state.TerritorySurveyed == "" {
+		t.Fatal("expected TerritorySurveyed to be set after finalize")
+	}
+}
+
 func TestSurveyDispatchContractWithTimeoutOverride(t *testing.T) {
 	contract := surveyDispatchContractWithTimeout(6 * time.Minute)
 	if got, ok := contract["worker_timeout_seconds"].(int); !ok || got != 360 {

--- a/cmd/codex_visuals.go
+++ b/cmd/codex_visuals.go
@@ -592,7 +592,13 @@ func renderColonizeVisual(result map[string]interface{}) string {
 	var b strings.Builder
 	b.WriteString(renderBanner(commandEmoji("colonize"), "Colonize"))
 	b.WriteString(visualDivider)
-	b.WriteString("Territory survey complete.\n")
+	dispatchMode := strings.TrimSpace(stringValue(result["dispatch_mode"]))
+	requiresFinalizer, _ := result["requires_finalizer"].(bool)
+	if requiresFinalizer || dispatchMode == "agent-delegate" || dispatchMode == "plan-only" {
+		b.WriteString("Territory survey manifest ready.\n")
+	} else {
+		b.WriteString("Territory survey complete.\n")
+	}
 	b.WriteString("Root: ")
 	b.WriteString(stringValue(result["root"]))
 	b.WriteString("\n")
@@ -625,7 +631,6 @@ func renderColonizeVisual(result map[string]interface{}) string {
 	if surveyors, ok := result["surveyors"].([]interface{}); ok && len(surveyors) > 0 {
 		dispatches := parseSurveyorMaps(surveyors)
 		hasRealData := hasRealExecutionData(dispatches)
-		dispatchMode := strings.TrimSpace(stringValue(result["dispatch_mode"]))
 		if dispatchMode == "" {
 			if hasRealData {
 				dispatchMode = "real"
@@ -663,7 +668,18 @@ func renderColonizeVisual(result map[string]interface{}) string {
 	b.WriteString("\nCoordination: ")
 	b.WriteString(displayDataPath("spawn-tree.txt"))
 	b.WriteString("\n")
-	b.WriteString(renderNextUp(`Run ` + "`aether plan`" + ` to turn this scan into a phase plan.`))
+	if requiresFinalizer || dispatchMode == "agent-delegate" || dispatchMode == "plan-only" {
+		finalizer := strings.TrimSpace(stringValue(result["finalizer_command"]))
+		if finalizer == "" {
+			finalizer = "aether colonize-finalize --completion-file <file>"
+		}
+		b.WriteString(renderNextUp(
+			`Host platform should dispatch the surveyors above, then run `+"`"+finalizer+"`"+`.`,
+			`Do not hand-edit `+"`.aether/data/`"+`; the finalizer writes survey state.`,
+		))
+	} else {
+		b.WriteString(renderNextUp(`Run ` + "`aether plan`" + ` to turn this scan into a phase plan.`))
+	}
 	return b.String()
 }
 
@@ -699,12 +715,14 @@ func parseSurveyorMaps(surveyors []interface{}) []codexSurveyorDispatch {
 			continue
 		}
 		d := codexSurveyorDispatch{
-			Caste:    stringValue(entry["caste"]),
-			Name:     stringValue(entry["name"]),
-			Task:     stringValue(entry["task"]),
-			Status:   stringValue(entry["status"]),
-			Summary:  stringValue(entry["summary"]),
-			Duration: floatValue(entry["duration"]),
+			Caste:     stringValue(entry["caste"]),
+			Name:      stringValue(entry["name"]),
+			Task:      stringValue(entry["task"]),
+			TaskID:    stringValue(entry["task_id"]),
+			AgentName: stringValue(entry["agent_name"]),
+			Status:    stringValue(entry["status"]),
+			Summary:   stringValue(entry["summary"]),
+			Duration:  floatValue(entry["duration"]),
 		}
 		if outputs, ok := entry["outputs"].([]interface{}); ok {
 			for _, o := range outputs {

--- a/cmd/codex_workflow_cmds.go
+++ b/cmd/codex_workflow_cmds.go
@@ -33,6 +33,7 @@ var colonizeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		forceResurvey, _ := cmd.Flags().GetBool("force-resurvey")
 		forceAlias, _ := cmd.Flags().GetBool("force")
+		planOnly, _ := cmd.Flags().GetBool("plan-only")
 		workerTimeout, err := resolveWorkerTimeoutFlag(cmd)
 		if err != nil {
 			outputError(1, err.Error(), nil)
@@ -41,6 +42,7 @@ var colonizeCmd = &cobra.Command{
 		result, err := runCodexColonizeWithOptions(skillWorkspaceRoot(), codexColonizeOptions{
 			ForceResurvey: forceResurvey || forceAlias,
 			WorkerTimeout: workerTimeout,
+			PlanOnly:      planOnly,
 		})
 		if err != nil {
 			outputError(1, err.Error(), nil)
@@ -960,6 +962,7 @@ func init() {
 	layEggsCmd.Flags().String("home-dir", "", "User home directory (default: $HOME)")
 	colonizeCmd.Flags().Bool("force-resurvey", false, "Refresh survey artifacts even when an existing survey is present")
 	colonizeCmd.Flags().Bool("force", false, "Alias for --force-resurvey")
+	colonizeCmd.Flags().Bool("plan-only", false, "Print the surveyor dispatch manifest without mutating colony state or spawning workers")
 	colonizeCmd.Flags().Duration("worker-timeout", 0, "Override per-worker timeout for real surveyor dispatches (e.g. 5m)")
 	planCmd.Flags().Bool("refresh", false, "Regenerate the plan even when an existing plan is already present")
 	planCmd.Flags().Bool("force", false, "Alias for --refresh")
@@ -970,6 +973,7 @@ func init() {
 	planCmd.Flags().Bool("synthetic", false, "Skip real worker dispatch and use local synthesis only")
 	planCmd.Flags().Duration("worker-timeout", 0, "Override per-worker timeout for real planning dispatches (e.g. 5m)")
 	planFinalizeCmd.Flags().String("completion-file", "", "JSON file containing plan_manifest and external planning worker results (use - for stdin)")
+	colonizeFinalizeCmd.Flags().String("completion-file", "", "JSON file containing colonize_manifest and external surveyor worker results (use - for stdin)")
 	buildCmd.Flags().StringArray("task", nil, "Redispatch only the specified task ID (repeatable or comma-separated)")
 	buildCmd.Flags().Bool("force", false, "Force redispatch of the current active phase after an interrupted build")
 	buildCmd.Flags().Bool("plan-only", false, "Print the build dispatch manifest without mutating colony state or spawning workers")
@@ -1002,6 +1006,7 @@ func init() {
 
 	rootCmd.AddCommand(layEggsCmd)
 	rootCmd.AddCommand(colonizeCmd)
+	rootCmd.AddCommand(colonizeFinalizeCmd)
 	rootCmd.AddCommand(planCmd)
 	rootCmd.AddCommand(planFinalizeCmd)
 	rootCmd.AddCommand(buildCmd)

--- a/cmd/command_guide.go
+++ b/cmd/command_guide.go
@@ -206,6 +206,27 @@ func commandGuideCatalog() map[string]commandGuideDefinition {
 		RawBypass:   "If the user explicitly asks for raw/exact/no-orchestration plan, run their literal `aether plan ...` command.",
 	}
 
+	catalog["colonize"] = commandGuideDefinition{
+		Category:       commandGuideCategoryFullOrchestration,
+		SkillReference: commandGuideSkillBuildCycle,
+		Intent:         "Use the runtime survey manifest to spawn visible platform surveyors and finalize survey state without hand-writing data files.",
+		Literal:        false,
+		PreSteps: []string{
+			"Use the generated platform slash-command wrapper for `colonize`; do not copy repo-local legacy commands back into target repos.",
+			"Run `AETHER_OUTPUT_MODE=json aether colonize --plan-only $ARGUMENTS` and parse `result.colonize_manifest`.",
+			"If runtime returns `dispatch_mode: agent-delegate`, dispatch the four Surveyor workers through the host platform instead of nested subprocess workers.",
+			"Use runtime-provided agent names, castes, task IDs, briefs, output_paths, and skill_section values.",
+			"Call `aether spawn-log` before each surveyor and `aether spawn-complete` after each terminal result.",
+		},
+		RunCommand: "AETHER_OUTPUT_MODE=json aether colonize-finalize --completion-file <worker completion JSON>",
+		PostSteps: []string{
+			"Summarize actual surveyors, survey files, and any runtime-surfaced warning.",
+			"Route first to `aether plan`.",
+		},
+		DriftGuards: intelligentCommandDriftGuards("colonize", commandGuideSkillBuildCycle),
+		RawBypass:   "If the user explicitly asks for raw/exact/no-orchestration colonize, run their literal `aether colonize ...` command.",
+	}
+
 	catalog["build"] = commandGuideDefinition{
 		Category:       commandGuideCategoryFullOrchestration,
 		SkillReference: commandGuideSkillBuildCycle,
@@ -294,7 +315,6 @@ func commandGuideLiteralCommands() []string {
 		"assumptions",
 		"bump-version",
 		"chaos",
-		"colonize",
 		"council",
 		"data-clean",
 		"dream",

--- a/cmd/command_guide_test.go
+++ b/cmd/command_guide_test.go
@@ -56,6 +56,7 @@ func TestCommandGuideIntelligentCommandsHaveOrchestration(t *testing.T) {
 	}{
 		"init":     {commandGuideCategoryFullOrchestration, commandGuideSkillCreation},
 		"oracle":   {commandGuideCategoryFullOrchestration, commandGuideSkillResearch},
+		"colonize": {commandGuideCategoryFullOrchestration, commandGuideSkillBuildCycle},
 		"plan":     {commandGuideCategoryFullOrchestration, commandGuideSkillBuildCycle},
 		"build":    {commandGuideCategoryFullOrchestration, commandGuideSkillBuildCycle},
 		"continue": {commandGuideCategorySemiIntelligent, commandGuideSkillBuildCycle},
@@ -153,7 +154,7 @@ func TestCommandGuideYamlCodexMetadataMatches(t *testing.T) {
 		t.Fatalf("failed to find repo root: %v", err)
 	}
 
-	for _, command := range []string{"init", "oracle", "plan", "build", "continue", "seal", "discuss"} {
+	for _, command := range []string{"init", "oracle", "colonize", "plan", "build", "continue", "seal", "discuss"} {
 		guide, err := buildCommandGuide(command, "codex")
 		if err != nil {
 			t.Fatalf("buildCommandGuide(%q): %v", command, err)
@@ -181,7 +182,7 @@ func TestIntelligentWrappersCarryCodexDriftGuard(t *testing.T) {
 		t.Fatalf("failed to find repo root: %v", err)
 	}
 
-	commands := []string{"init", "oracle", "plan", "build", "continue", "seal", "discuss"}
+	commands := []string{"init", "oracle", "colonize", "plan", "build", "continue", "seal", "discuss"}
 	wrapperDirs := []string{
 		filepath.Join(repoRoot, ".claude", "commands", "ant"),
 		filepath.Join(repoRoot, ".opencode", "commands", "ant"),

--- a/cmd/platform_doc_hygiene_test.go
+++ b/cmd/platform_doc_hygiene_test.go
@@ -258,7 +258,9 @@ func TestLifecycleCommandDocsPreferRuntimeCLI(t *testing.T) {
 			path: ".claude/commands/ant/colonize.md",
 			required: []string{
 				"Use the Go `aether` CLI as the source of truth.",
-				"AETHER_OUTPUT_MODE=visual aether colonize $ARGUMENTS",
+				"AETHER_OUTPUT_MODE=json aether colonize --plan-only $ARGUMENTS",
+				"AETHER_OUTPUT_MODE=json aether colonize-finalize --completion-file",
+				"colonize_manifest",
 			},
 			forbidden: []string{
 				"Write a minimal COLONY_STATE.json",
@@ -547,11 +549,12 @@ func TestLifecycleCommandDocsPreferRuntimeCLI(t *testing.T) {
 			path: ".opencode/commands/ant/colonize.md",
 			required: []string{
 				"Use the Go `aether` CLI as the source of truth.",
-				"AETHER_OUTPUT_MODE=visual aether colonize $ARGUMENTS",
+				"AETHER_OUTPUT_MODE=json aether colonize --plan-only $ARGUMENTS",
+				"AETHER_OUTPUT_MODE=json aether colonize-finalize --completion-file",
+				"colonize_manifest",
 			},
 			forbidden: []string{
 				"Write a minimal COLONY_STATE.json",
-				"Spawn 4 Surveyor Ants in parallel",
 				".aether/aether-utils.sh",
 			},
 		},


### PR DESCRIPTION
## Summary
- add `aether colonize --plan-only` manifest mode and `colonize-finalize` for host-spawned surveyors
- update Claude/OpenCode global colonize wrappers to dispatch visible platform agents from the manifest
- align Codex command-guide/docs tests and visual output for manifest/finalizer flow

## Verification
- `go test ./cmd -run 'TestColonizePlanOnly|TestColonizeFinalize|TestColonizeCommand|TestColonizeIncludes|TestClaudeOpenCodeCommandParity' -count=1`
- `go build ./cmd/aether`
- `go vet ./...`
- `go test ./... -count=1`