### PR TITLE
Restore host-orchestrated swarm flow

### DIFF
--- a/.aether/commands/swarm.yaml
+++ b/.aether/commands/swarm.yaml
@@ -1,8 +1,34 @@
 name: ant-swarm
-description: "🔥 Real-time colony swarm display + stubborn bug destroyer"
+description: "🔥 Real-time colony swarm display + visible bug-destroyer workers"
 source_of_truth: "Use the Go `aether` CLI as the source of truth."
 runtime:
-  command: "AETHER_OUTPUT_MODE=visual aether swarm $ARGUMENTS"
+  command: "AETHER_OUTPUT_MODE=json aether swarm --plan-only $ARGUMENTS"
+codex_orchestration:
+  category: "full-orchestration"
+  skill: "aether-colony-build-cycle"
+  guide: "aether command-guide swarm --platform codex"
+  drift_guard: "Update this YAML, Claude/OpenCode wrappers, the Codex skill, and cmd/command_guide.go together."
+wrapper_additions:
+  watch: |
+    Keep live visibility direct:
+    - If the user provides no problem description, run `AETHER_OUTPUT_MODE=visual aether swarm --watch`.
+    - Do not request a manifest for watch mode.
+  orchestration: |
+    Restore host-visible bug-destroyer orchestration:
+    1. Run `AETHER_OUTPUT_MODE=json aether swarm --plan-only $ARGUMENTS`.
+    2. Parse `result.swarm_manifest`; do not parse visual output.
+    3. For each manifest dispatch, call `aether spawn-log`, spawn the matching platform agent (`subagent_type` / equivalent) using `agent_name`, inject the dispatch `brief`, `response_contract`, active signals, and exact task metadata, then call `aether spawn-complete`.
+    4. Preserve the runtime wave order: investigation workers in wave 1 may run together, builder wave 2 waits for wave 1 summaries, watcher wave 3 waits for builder completion.
+    5. Collect terminal worker results into a completion JSON file containing the original `swarm_manifest` and a `dispatches` array.
+    6. Run `AETHER_OUTPUT_MODE=json aether swarm-finalize --completion-file <file>` to let the runtime write swarm artifacts, spawn-tree status, and the final result.
+  post_swarm: |
+    Close from `swarm-finalize` output only:
+    1. Summarize which workers actually ran, the root cause, the fix or blocker, and verification evidence.
+    2. Route first to the runtime-surfaced next command.
 guardrails:
+  - "Do NOT run nested subprocess swarm workers from Claude/OpenCode wrapper orchestration."
   - "Do not write colony state files, session files, or pheromone files by hand from this command spec."
+  - "Do not copy command wrappers into target repos; commands are published globally through the platform homes."
+  - "Do NOT parse visual output as authoritative state."
+  - "Do NOT run `aether swarm` without `--plan-only` from Claude/OpenCode bug-destroyer orchestration unless the user explicitly asks for raw/no-orchestration."
   - "If docs and runtime disagree, runtime wins."

--- a/.aether/skills/colony/aether-colony-build-cycle/SKILL.md
+++ b/.aether/skills/colony/aether-colony-build-cycle/SKILL.md
@@ -1,12 +1,12 @@
 ---
 source: shipped
 name: aether-colony-build-cycle
-description: Use when Codex is asked to plan, build, continue, or seal an Aether colony and must mirror wrapper orchestration safely
+description: Use when Codex is asked to plan, build, continue, swarm, or seal an Aether colony and must mirror wrapper orchestration safely
 type: colony
-domains: [aether, codex, planning, build, verification, seal, orchestration]
-agent_roles: [queen, builder, watcher, scout, route_setter, auditor, probe]
-workflow_triggers: [plan, build, continue, seal]
-task_keywords: [aether plan, aether build, aether continue, aether seal, dispatch manifest, plan-only, finalize]
+domains: [aether, codex, planning, build, verification, swarm, seal, orchestration]
+agent_roles: [queen, builder, watcher, scout, route_setter, tracker, archaeologist, auditor, probe]
+workflow_triggers: [plan, build, continue, swarm, seal]
+task_keywords: [aether plan, aether build, aether continue, aether swarm, aether seal, dispatch manifest, plan-only, finalize]
 priority: high
 version: "1.0"
 ---
@@ -16,7 +16,7 @@ version: "1.0"
 ## Purpose
 
 Give Codex the wrapper-equivalent behavior for the lifecycle commands where AI
-orchestration matters: `plan`, `build`, `continue`, and `seal`. Runtime JSON
+orchestration matters: `plan`, `build`, `continue`, `swarm`, and `seal`. Runtime JSON
 manifests remain authoritative. Codex may spawn workers and summarize results,
 but it must not invent state or write state files by hand.
 
@@ -28,7 +28,7 @@ can coordinate helpers, but it must use the recipe the runtime gave it.
 Run or inspect the guide for the command being handled:
 
 ```bash
-aether command-guide <plan|build|continue|seal> --platform codex
+aether command-guide <plan|build|continue|swarm|seal> --platform codex
 ```
 
 If this skill and `command-guide` disagree, follow `command-guide` and update
@@ -96,6 +96,33 @@ Use external review orchestration only when the user explicitly requested heavy
 review or the runtime asks for wrapper-spawned review workers. In that case,
 request the runtime manifest, spawn only the planned reviewers, collect results,
 and finalize through `aether continue-finalize`.
+
+## Swarm Flow
+
+Watch mode stays direct:
+
+```bash
+AETHER_OUTPUT_MODE=visual aether swarm --watch
+```
+
+For bug-destroyer targets, use the external worker contract:
+
+```bash
+AETHER_OUTPUT_MODE=json aether swarm --plan-only <problem>
+```
+
+1. Parse `result.swarm_manifest`. Never parse visual output as state.
+2. Preserve manifest wave order: investigation workers first, then builder,
+   then watcher.
+3. Use runtime-provided names, castes, roles, task IDs, briefs, and response
+   contracts.
+4. Call `aether spawn-log` before each worker and `aether spawn-complete` after
+   each terminal result.
+5. Finalize through:
+
+```bash
+AETHER_OUTPUT_MODE=json aether swarm-finalize --completion-file <worker completion JSON>
+```
 
 ## Seal Flow
 

--- a/.claude/commands/ant/swarm.md
+++ b/.claude/commands/ant/swarm.md
@@ -1,13 +1,116 @@
 <!-- Generated from .aether/commands/swarm.yaml - DO NOT EDIT DIRECTLY -->
 ---
 name: ant-swarm
-description: "🔥 Real-time colony swarm display + stubborn bug destroyer"
+description: "🔥 Real-time colony swarm display + visible bug-destroyer workers"
 ---
 
-Use the Go `aether` CLI as the source of truth.
+Use the Go `aether` CLI as the source of truth. The runtime owns swarm artifacts, spawn-tree status, worker wave contracts, and final result persistence. The wrapper owns only visible platform worker ceremony.
 
-- For live worker visibility, execute `AETHER_OUTPUT_MODE=visual aether swarm --watch`.
-- To launch the stubborn bug-destroyer flow, execute `AETHER_OUTPUT_MODE=visual aether swarm "$ARGUMENTS"` directly.
-- The runtime owns the investigate -> fix -> verify worker waves. Do not hand-edit `.aether/data/` or manually reconstruct swarm artifacts.
-- If the user provides no problem description, prefer `aether swarm --watch`.
+## Watch Mode
+
+If the user provides no problem description, keep live visibility direct:
+
+```
+AETHER_OUTPUT_MODE=visual aether swarm --watch
+```
+
+Do not request a manifest for watch mode.
+
+## Swarm Manifest
+
+For a bug-destroyer target, ask the runtime for the authoritative swarm manifest:
+
+```
+AETHER_OUTPUT_MODE=json aether swarm --plan-only $ARGUMENTS
+```
+
+Parse `result.swarm_manifest`. This manifest is the only source for worker names, castes, roles, waves, task IDs, agent names, briefs, response contracts, and finalizer contract.
+
+If the runtime returns `dispatch_mode: agent-delegate`, this is the expected hosted-agent path. Do not run nested subprocess swarm workers. Dispatch the manifest workers through the current platform.
+
+## Wave Execution
+
+For each dispatch in `swarm_manifest.dispatches`:
+
+1. Run:
+   `AETHER_OUTPUT_MODE=json aether spawn-log --parent "Swarm" --caste "{caste}" --name "{name}" --task "{task}" --depth 1`
+2. Spawn the matching platform agent using `subagent_type="{agent_name}"` or the platform equivalent.
+3. Use a concise agent description: `🔥 Swarm {name}: {role}`.
+4. Inject the dispatch `brief`, `response_contract`, active signals, and exact task metadata.
+5. Require every worker to return a terminal structured result with: `name`, `caste`, `role`, `task`, `status`, `summary`, `files`, `tests`, `blockers`, `response`, and `duration`.
+6. After each worker returns, run:
+   `AETHER_OUTPUT_MODE=json aether spawn-complete --name "{name}" --status "{status}" --summary "{summary}"`
+
+Preserve the runtime wave order:
+
+1. Wave 1 investigation workers may run together.
+2. Wave 2 builder waits for wave 1 summaries.
+3. Wave 3 watcher waits for builder completion.
+
+The wrapper must not invent worker names, roles, or waves.
+
+## Completion Packet
+
+After all swarm workers have terminal results, write a temporary completion JSON file outside `.aether/data/`:
+
+```json
+{
+  "swarm_manifest": {
+    "...": "the exact result.swarm_manifest object"
+  },
+  "dispatches": [
+    {
+      "name": "Trace-12",
+      "caste": "tracker",
+      "role": "tracker",
+      "task": "Reproduce the issue and trace the failure path.",
+      "status": "completed",
+      "summary": "Tracked the issue to a missing nil guard.",
+      "files": [],
+      "tests": [],
+      "blockers": [],
+      "duration": 0,
+      "response": {
+        "role": "tracker",
+        "status": "completed",
+        "summary": "Tracked the issue to a missing nil guard.",
+        "findings": ["The panic starts in the session lookup path."],
+        "evidence": ["pkg/auth/handler.go"],
+        "root_cause": "missing session guard",
+        "recommendation": "Restore the guard and add a regression test.",
+        "proposed_fix": "",
+        "files_touched": [],
+        "tests_written": [],
+        "verification": []
+      }
+    }
+  ]
+}
+```
+
+Then finalize through the runtime:
+
+```
+AETHER_OUTPUT_MODE=json aether swarm-finalize --completion-file <completion_file>
+```
+
+## After Swarm
+
+Branch strictly on `swarm-finalize` output:
+
+1. Summarize which workers actually ran.
+2. Summarize the root cause, fix or blocker, files/tests touched, and verification evidence.
+3. Route first to the runtime-surfaced `next` command.
+
+## Cross-Platform Drift Guard
+
+If you change swarm manifest handling, worker spawning, finalization, or closeout behavior here, update `.aether/commands/swarm.yaml`, both platform swarm wrappers, the Codex skill `aether-colony-build-cycle`, and `cmd/command_guide.go` in the same change. Verify `aether command-guide swarm --platform codex` still describes the matching Codex flow.
+
+## Guardrails
+
+- Do NOT run nested subprocess swarm workers from this wrapper.
+- Do NOT run `aether swarm` without `--plan-only` from this wrapper unless the user explicitly asks for raw/no-orchestration.
+- Do NOT hand-edit `.aether/data/`, `COLONY_STATE.json`, `session.json`, or pheromone files.
+- Do NOT copy command wrappers into target repos; Aether commands are published globally.
+- Do NOT invent worker names, castes, roles, waves, task IDs, or outputs; use `swarm_manifest`.
 - If docs and runtime disagree, runtime wins.

--- a/.opencode/commands/ant/swarm.md
+++ b/.opencode/commands/ant/swarm.md
@@ -1,13 +1,116 @@
 <!-- Generated from .aether/commands/swarm.yaml - DO NOT EDIT DIRECTLY -->
 ---
 name: ant-swarm
-description: "🔥 Real-time colony swarm display + stubborn bug destroyer"
+description: "🔥 Real-time colony swarm display + visible bug-destroyer workers"
 ---
 
-Use the Go `aether` CLI as the source of truth.
+Use the Go `aether` CLI as the source of truth. The runtime owns swarm artifacts, spawn-tree status, worker wave contracts, and final result persistence. The wrapper owns only visible platform worker ceremony.
 
-- For live worker visibility, execute `AETHER_OUTPUT_MODE=visual aether swarm --watch`.
-- To launch the stubborn bug-destroyer flow, execute `AETHER_OUTPUT_MODE=visual aether swarm "$ARGUMENTS"` directly.
-- The runtime owns the investigate -> fix -> verify worker waves. Do not hand-edit `.aether/data/` or manually reconstruct swarm artifacts.
-- If the user provides no problem description, prefer `aether swarm --watch`.
+## Watch Mode
+
+If the user provides no problem description, keep live visibility direct:
+
+```
+AETHER_OUTPUT_MODE=visual aether swarm --watch
+```
+
+Do not request a manifest for watch mode.
+
+## Swarm Manifest
+
+For a bug-destroyer target, ask the runtime for the authoritative swarm manifest:
+
+```
+AETHER_OUTPUT_MODE=json aether swarm --plan-only $ARGUMENTS
+```
+
+Parse `result.swarm_manifest`. This manifest is the only source for worker names, castes, roles, waves, task IDs, agent names, briefs, response contracts, and finalizer contract.
+
+If the runtime returns `dispatch_mode: agent-delegate`, this is the expected hosted-agent path. Do not run nested subprocess swarm workers. Dispatch the manifest workers through the current platform.
+
+## Wave Execution
+
+For each dispatch in `swarm_manifest.dispatches`:
+
+1. Run:
+   `AETHER_OUTPUT_MODE=json aether spawn-log --parent "Swarm" --caste "{caste}" --name "{name}" --task "{task}" --depth 1`
+2. Spawn the matching platform agent using `subagent_type="{agent_name}"` or the platform equivalent.
+3. Use a concise agent description: `🔥 Swarm {name}: {role}`.
+4. Inject the dispatch `brief`, `response_contract`, active signals, and exact task metadata.
+5. Require every worker to return a terminal structured result with: `name`, `caste`, `role`, `task`, `status`, `summary`, `files`, `tests`, `blockers`, `response`, and `duration`.
+6. After each worker returns, run:
+   `AETHER_OUTPUT_MODE=json aether spawn-complete --name "{name}" --status "{status}" --summary "{summary}"`
+
+Preserve the runtime wave order:
+
+1. Wave 1 investigation workers may run together.
+2. Wave 2 builder waits for wave 1 summaries.
+3. Wave 3 watcher waits for builder completion.
+
+The wrapper must not invent worker names, roles, or waves.
+
+## Completion Packet
+
+After all swarm workers have terminal results, write a temporary completion JSON file outside `.aether/data/`:
+
+```json
+{
+  "swarm_manifest": {
+    "...": "the exact result.swarm_manifest object"
+  },
+  "dispatches": [
+    {
+      "name": "Trace-12",
+      "caste": "tracker",
+      "role": "tracker",
+      "task": "Reproduce the issue and trace the failure path.",
+      "status": "completed",
+      "summary": "Tracked the issue to a missing nil guard.",
+      "files": [],
+      "tests": [],
+      "blockers": [],
+      "duration": 0,
+      "response": {
+        "role": "tracker",
+        "status": "completed",
+        "summary": "Tracked the issue to a missing nil guard.",
+        "findings": ["The panic starts in the session lookup path."],
+        "evidence": ["pkg/auth/handler.go"],
+        "root_cause": "missing session guard",
+        "recommendation": "Restore the guard and add a regression test.",
+        "proposed_fix": "",
+        "files_touched": [],
+        "tests_written": [],
+        "verification": []
+      }
+    }
+  ]
+}
+```
+
+Then finalize through the runtime:
+
+```
+AETHER_OUTPUT_MODE=json aether swarm-finalize --completion-file <completion_file>
+```
+
+## After Swarm
+
+Branch strictly on `swarm-finalize` output:
+
+1. Summarize which workers actually ran.
+2. Summarize the root cause, fix or blocker, files/tests touched, and verification evidence.
+3. Route first to the runtime-surfaced `next` command.
+
+## Cross-Platform Drift Guard
+
+If you change swarm manifest handling, worker spawning, finalization, or closeout behavior here, update `.aether/commands/swarm.yaml`, both platform swarm wrappers, the Codex skill `aether-colony-build-cycle`, and `cmd/command_guide.go` in the same change. Verify `aether command-guide swarm --platform codex` still describes the matching Codex flow.
+
+## Guardrails
+
+- Do NOT run nested subprocess swarm workers from this wrapper.
+- Do NOT run `aether swarm` without `--plan-only` from this wrapper unless the user explicitly asks for raw/no-orchestration.
+- Do NOT hand-edit `.aether/data/`, `COLONY_STATE.json`, `session.json`, or pheromone files.
+- Do NOT copy command wrappers into target repos; Aether commands are published globally.
+- Do NOT invent worker names, castes, roles, waves, task IDs, or outputs; use `swarm_manifest`.
 - If docs and runtime disagree, runtime wins.

--- a/cmd/command_guide.go
+++ b/cmd/command_guide.go
@@ -227,6 +227,27 @@ func commandGuideCatalog() map[string]commandGuideDefinition {
 		RawBypass:   "If the user explicitly asks for raw/exact/no-orchestration colonize, run their literal `aether colonize ...` command.",
 	}
 
+	catalog["swarm"] = commandGuideDefinition{
+		Category:       commandGuideCategoryFullOrchestration,
+		SkillReference: commandGuideSkillBuildCycle,
+		Intent:         "Use the runtime swarm manifest to spawn visible bug-destroyer workers and finalize swarm artifacts without hand-writing data files.",
+		Literal:        false,
+		PreSteps: []string{
+			"If the user provides no problem description, use the generated wrapper's direct watch path: `AETHER_OUTPUT_MODE=visual aether swarm --watch`.",
+			"For bug-destroyer targets, run `AETHER_OUTPUT_MODE=json aether swarm --plan-only $ARGUMENTS` and parse `result.swarm_manifest`.",
+			"Dispatch wave 1 investigation workers through the host platform, then wave 2 builder, then wave 3 watcher.",
+			"Use runtime-provided agent names, castes, roles, waves, task IDs, briefs, and response contracts.",
+			"Call `aether spawn-log` before each worker and `aether spawn-complete` after each terminal result.",
+		},
+		RunCommand: "AETHER_OUTPUT_MODE=json aether swarm-finalize --completion-file <worker completion JSON>",
+		PostSteps: []string{
+			"Summarize actual workers, root cause, fix or blocker, and verification evidence.",
+			"Route first to the runtime-surfaced `next` command.",
+		},
+		DriftGuards: intelligentCommandDriftGuards("swarm", commandGuideSkillBuildCycle),
+		RawBypass:   "If the user explicitly asks for raw/exact/no-orchestration swarm, run their literal `aether swarm ...` command.",
+	}
+
 	catalog["build"] = commandGuideDefinition{
 		Category:       commandGuideCategoryFullOrchestration,
 		SkillReference: commandGuideSkillBuildCycle,
@@ -358,7 +379,6 @@ func commandGuideLiteralCommands() []string {
 		"shelf-promote",
 		"skill-create",
 		"status",
-		"swarm",
 		"tunnels",
 		"update",
 		"verify-castes",

--- a/cmd/command_guide_test.go
+++ b/cmd/command_guide_test.go
@@ -57,6 +57,7 @@ func TestCommandGuideIntelligentCommandsHaveOrchestration(t *testing.T) {
 		"init":     {commandGuideCategoryFullOrchestration, commandGuideSkillCreation},
 		"oracle":   {commandGuideCategoryFullOrchestration, commandGuideSkillResearch},
 		"colonize": {commandGuideCategoryFullOrchestration, commandGuideSkillBuildCycle},
+		"swarm":    {commandGuideCategoryFullOrchestration, commandGuideSkillBuildCycle},
 		"plan":     {commandGuideCategoryFullOrchestration, commandGuideSkillBuildCycle},
 		"build":    {commandGuideCategoryFullOrchestration, commandGuideSkillBuildCycle},
 		"continue": {commandGuideCategorySemiIntelligent, commandGuideSkillBuildCycle},
@@ -154,7 +155,7 @@ func TestCommandGuideYamlCodexMetadataMatches(t *testing.T) {
 		t.Fatalf("failed to find repo root: %v", err)
 	}
 
-	for _, command := range []string{"init", "oracle", "colonize", "plan", "build", "continue", "seal", "discuss"} {
+	for _, command := range []string{"init", "oracle", "colonize", "swarm", "plan", "build", "continue", "seal", "discuss"} {
 		guide, err := buildCommandGuide(command, "codex")
 		if err != nil {
 			t.Fatalf("buildCommandGuide(%q): %v", command, err)
@@ -182,7 +183,7 @@ func TestIntelligentWrappersCarryCodexDriftGuard(t *testing.T) {
 		t.Fatalf("failed to find repo root: %v", err)
 	}
 
-	commands := []string{"init", "oracle", "colonize", "plan", "build", "continue", "seal", "discuss"}
+	commands := []string{"init", "oracle", "colonize", "swarm", "plan", "build", "continue", "seal", "discuss"}
 	wrapperDirs := []string{
 		filepath.Join(repoRoot, ".claude", "commands", "ant"),
 		filepath.Join(repoRoot, ".opencode", "commands", "ant"),

--- a/cmd/platform_doc_hygiene_test.go
+++ b/cmd/platform_doc_hygiene_test.go
@@ -269,6 +269,22 @@ func TestLifecycleCommandDocsPreferRuntimeCLI(t *testing.T) {
 			},
 		},
 		{
+			path: ".claude/commands/ant/swarm.md",
+			required: []string{
+				"Use the Go `aether` CLI as the source of truth.",
+				"AETHER_OUTPUT_MODE=visual aether swarm --watch",
+				"AETHER_OUTPUT_MODE=json aether swarm --plan-only $ARGUMENTS",
+				"result.swarm_manifest",
+				"AETHER_OUTPUT_MODE=json aether spawn-log",
+				"AETHER_OUTPUT_MODE=json aether swarm-finalize --completion-file",
+			},
+			forbidden: []string{
+				"AETHER_OUTPUT_MODE=visual aether swarm \"$ARGUMENTS\"",
+				"manually reconstruct swarm artifacts",
+				".aether/aether-utils.sh",
+			},
+		},
+		{
 			path: ".claude/commands/ant/seal.md",
 			required: []string{
 				"Use the Go `aether` CLI as the source of truth.",

--- a/cmd/swarm_cmd.go
+++ b/cmd/swarm_cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -25,13 +26,19 @@ const (
 var newSwarmWorkerInvoker = codex.NewWorkerInvoker
 
 type swarmWorkerPlan struct {
-	Name      string
-	Caste     string
-	Role      string
-	Task      string
-	AgentName string
-	Wave      int
-	Timeout   time.Duration
+	Stage            string                 `json:"stage,omitempty"`
+	Wave             int                    `json:"wave"`
+	Name             string                 `json:"name"`
+	Caste            string                 `json:"caste"`
+	Role             string                 `json:"role"`
+	Task             string                 `json:"task"`
+	TaskID           string                 `json:"task_id,omitempty"`
+	AgentName        string                 `json:"agent_name"`
+	Brief            string                 `json:"brief,omitempty"`
+	OutputPaths      []string               `json:"output_paths,omitempty"`
+	ResponseContract map[string]interface{} `json:"response_contract,omitempty"`
+	TimeoutSeconds   int                    `json:"timeout_seconds,omitempty"`
+	Timeout          time.Duration          `json:"-"`
 }
 
 type swarmWorkerResponse struct {
@@ -64,6 +71,34 @@ type swarmWorkerExecution struct {
 	ResponsePath string              `json:"response_path,omitempty"`
 }
 
+type swarmManifest struct {
+	Workflow             string                   `json:"workflow"`
+	DispatchMode         string                   `json:"dispatch_mode"`
+	RequiresFinalizer    bool                     `json:"requires_finalizer"`
+	GeneratedAt          string                   `json:"generated_at"`
+	Root                 string                   `json:"root"`
+	SwarmID              string                   `json:"swarm_id"`
+	Target               string                   `json:"target"`
+	WaveCount            int                      `json:"wave_count"`
+	WorkerCount          int                      `json:"worker_count"`
+	RunTimeoutSeconds    int                      `json:"run_timeout_seconds"`
+	WorkerTimeoutSeconds int                      `json:"worker_timeout_seconds"`
+	DispatchContract     map[string]interface{}   `json:"dispatch_contract"`
+	Dispatches           []swarmWorkerPlan        `json:"dispatches"`
+	ExecutionPlan        []map[string]interface{} `json:"execution_plan"`
+	FinalizerCommand     string                   `json:"finalizer_command"`
+}
+
+type externalSwarmCompletion struct {
+	SwarmManifest *swarmManifest         `json:"swarm_manifest,omitempty"`
+	Manifest      *swarmManifest         `json:"manifest,omitempty"`
+	Dispatches    []swarmWorkerExecution `json:"dispatches,omitempty"`
+	Workers       []swarmWorkerExecution `json:"workers,omitempty"`
+	Results       []swarmWorkerExecution `json:"results,omitempty"`
+	Responses     []swarmWorkerResponse  `json:"responses,omitempty"`
+	WorkerResults []codex.WorkerResult   `json:"worker_results,omitempty"`
+}
+
 var swarmCmd = &cobra.Command{
 	Use:   "swarm [problem]",
 	Short: "Launch the Aether swarm bug-destroyer or watch live colony activity",
@@ -75,10 +110,32 @@ var swarmCmd = &cobra.Command{
 		}
 
 		watch, _ := cmd.Flags().GetBool("watch")
+		planOnly, _ := cmd.Flags().GetBool("plan-only")
 		target := strings.TrimSpace(strings.Join(args, " "))
 		root := resolveAetherRootPath()
 
-		result, err := runSwarmCompatibility(root, target, watch)
+		result, err := runSwarmCompatibility(root, target, watch, planOnly)
+		if err != nil {
+			outputError(1, err.Error(), nil)
+			return nil
+		}
+		outputWorkflow(result, renderSwarmCompatibilityVisual(result))
+		return nil
+	},
+}
+
+var swarmFinalizeCmd = &cobra.Command{
+	Use:   "swarm-finalize",
+	Short: "Record externally spawned swarm workers and write the swarm result",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		completionPath, _ := cmd.Flags().GetString("completion-file")
+		completion, err := loadExternalSwarmCompletion(completionPath)
+		if err != nil {
+			outputError(1, err.Error(), nil)
+			return nil
+		}
+		result, err := runSwarmFinalize(resolveAetherRootPath(), completion)
 		if err != nil {
 			outputError(1, err.Error(), nil)
 			return nil
@@ -90,12 +147,21 @@ var swarmCmd = &cobra.Command{
 
 func init() {
 	swarmCmd.Flags().Bool("watch", false, "Show live colony activity instead of launching a swarm run")
+	swarmCmd.Flags().Bool("plan-only", false, "Print a host-dispatch swarm manifest without running workers")
 	rootCmd.AddCommand(swarmCmd)
+	swarmFinalizeCmd.Flags().String("completion-file", "", "JSON file containing the swarm manifest and external worker results")
+	rootCmd.AddCommand(swarmFinalizeCmd)
 }
 
-func runSwarmCompatibility(root, target string, watch bool) (map[string]interface{}, error) {
+func runSwarmCompatibility(root, target string, watch, planOnly bool) (map[string]interface{}, error) {
 	if watch || strings.TrimSpace(target) == "" {
+		if planOnly && strings.TrimSpace(target) == "" && !watch {
+			return nil, fmt.Errorf("swarm --plan-only requires a problem description")
+		}
 		return buildSwarmWatchResult(target, watch, false), nil
+	}
+	if planOnly || codex.ShouldUseAgentDelegatePath() {
+		return runSwarmPlanOnly(root, target)
 	}
 	return runSwarmDestroy(root, target)
 }
@@ -288,6 +354,179 @@ func runSwarmDestroy(root, target string) (map[string]interface{}, error) {
 	}, nil
 }
 
+func runSwarmPlanOnly(root, target string) (map[string]interface{}, error) {
+	if store == nil {
+		return nil, fmt.Errorf("no store initialized")
+	}
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return nil, fmt.Errorf("swarm --plan-only requires a problem description")
+	}
+
+	dispatchMode := "plan-only"
+	status := "plan-only"
+	if codex.ShouldUseAgentDelegatePath() {
+		dispatchMode = "agent-delegate"
+		status = "agent-delegate"
+	}
+
+	manifest := buildSwarmManifest(root, target, dispatchMode, time.Now().UTC())
+	dispatchMaps := swarmPlanMaps(manifest.Dispatches)
+	return map[string]interface{}{
+		"mode":                  "destroy",
+		"status":                status,
+		"dispatch_mode":         dispatchMode,
+		"requires_finalizer":    true,
+		"execution_owner":       "host-platform",
+		"agent_delegate":        dispatchMode == "agent-delegate",
+		"agent_delegate_reason": strings.TrimSpace(codex.AgentDelegateFallbackReason()),
+		"swarm_id":              manifest.SwarmID,
+		"target":                target,
+		"root":                  root,
+		"swarm_manifest":        manifest,
+		"dispatch_manifest":     manifest,
+		"dispatches":            dispatchMaps,
+		"workers":               dispatchMaps,
+		"worker_count":          len(dispatchMaps),
+		"wave_count":            manifest.WaveCount,
+		"dispatch_contract":     manifest.DispatchContract,
+		"finalizer_command":     manifest.FinalizerCommand,
+		"next":                  "dispatch host swarm workers, then run `aether swarm-finalize --completion-file <file>`",
+		"watch":                 false,
+	}, nil
+}
+
+func buildSwarmManifest(root, target, dispatchMode string, now time.Time) swarmManifest {
+	swarmID := fmt.Sprintf("swarm-%d", now.Unix())
+	dispatches := allSwarmPlans(root, target)
+	for i := range dispatches {
+		dispatches[i] = enrichSwarmPlanForManifest(root, target, swarmID, dispatches[i])
+	}
+	return swarmManifest{
+		Workflow:             "swarm",
+		DispatchMode:         dispatchMode,
+		RequiresFinalizer:    true,
+		GeneratedAt:          now.Format(time.RFC3339),
+		Root:                 root,
+		SwarmID:              swarmID,
+		Target:               strings.TrimSpace(target),
+		WaveCount:            3,
+		WorkerCount:          len(dispatches),
+		RunTimeoutSeconds:    int(defaultSwarmRunTimeout / time.Second),
+		WorkerTimeoutSeconds: int(defaultSwarmWorkerTimeout / time.Second),
+		DispatchContract: map[string]interface{}{
+			"execution_model":        "3 waves: investigation, fix, verification",
+			"wave_count":             3,
+			"worker_count":           len(dispatches),
+			"coordination_path":      ".aether/data/spawn-tree.txt",
+			"artifact_path":          filepath.ToSlash(filepath.Join(".aether", "data", "swarms", swarmID, "result.json")),
+			"completion_shape":       "completion JSON must include swarm_manifest plus dispatches/workers/results",
+			"state_authority":        "runtime finalizer writes swarm artifacts and spawn-tree status",
+			"wrapper_write_policy":   "workers report structured terminal results to the wrapper; wrappers do not hand-edit .aether/data",
+			"run_timeout_seconds":    int(defaultSwarmRunTimeout / time.Second),
+			"worker_status_values":   []string{"completed", "passed", "code_written", "blocked", "failed", "timeout"},
+			"required_result_fields": []string{"name", "caste", "role", "task", "status", "summary"},
+		},
+		Dispatches:       dispatches,
+		ExecutionPlan:    swarmPlanMaps(dispatches),
+		FinalizerCommand: "AETHER_OUTPUT_MODE=json aether swarm-finalize --completion-file <file>",
+	}
+}
+
+func allSwarmPlans(root, target string) []swarmWorkerPlan {
+	plans := append([]swarmWorkerPlan{}, buildSwarmInvestigationPlans(root, target)...)
+	builder := buildSwarmBuilderPlan(root, target)
+	watcher := buildSwarmWatcherPlan(root, target)
+	plans = append(plans, builder, watcher)
+	return plans
+}
+
+func enrichSwarmPlanForManifest(root, target, swarmID string, plan swarmWorkerPlan) swarmWorkerPlan {
+	plan.Stage = swarmStageName(plan.Wave)
+	if strings.TrimSpace(plan.TaskID) == "" {
+		plan.TaskID = fmt.Sprintf("swarm.%s", plan.Role)
+	}
+	if plan.TimeoutSeconds == 0 {
+		plan.TimeoutSeconds = int(firstSwarmTimeout(plan.Timeout) / time.Second)
+	}
+	if len(plan.OutputPaths) == 0 {
+		plan.OutputPaths = []string{
+			filepath.ToSlash(filepath.Join(".aether", "external", "swarm", swarmID, plan.Name+".json")),
+		}
+	}
+	if plan.ResponseContract == nil {
+		plan.ResponseContract = map[string]interface{}{
+			"format": "terminal structured result in wrapper completion JSON",
+			"fields": []string{
+				"name", "caste", "role", "task", "status", "summary",
+				"files", "tests", "blockers", "response",
+			},
+			"response_fields": []string{
+				"role", "status", "summary", "findings", "evidence",
+				"root_cause", "recommendation", "proposed_fix",
+				"files_touched", "tests_written", "verification",
+			},
+		}
+	}
+	if strings.TrimSpace(plan.Brief) == "" {
+		plan.Brief = renderExternalSwarmWorkerBrief(root, target, swarmID, plan)
+	}
+	return plan
+}
+
+func swarmStageName(wave int) string {
+	switch wave {
+	case 1:
+		return "investigation"
+	case 2:
+		return "fix"
+	case 3:
+		return "verification"
+	default:
+		return "swarm"
+	}
+}
+
+func renderExternalSwarmWorkerBrief(root, target, swarmID string, plan swarmWorkerPlan) string {
+	var b strings.Builder
+	b.WriteString("Swarm ID: " + swarmID + "\n")
+	b.WriteString("Target: " + strings.TrimSpace(target) + "\n")
+	b.WriteString("Workspace: " + root + "\n")
+	b.WriteString("Role: " + plan.Role + "\n")
+	b.WriteString("Wave: " + fmt.Sprintf("%d", plan.Wave) + " (" + swarmStageName(plan.Wave) + ")\n\n")
+	b.WriteString("Assignment:\n")
+	b.WriteString(plan.Task)
+	b.WriteString("\n\nReturn a terminal structured result to the wrapper. Do not hand-edit `.aether/data/`; the wrapper will pass your result to `aether swarm-finalize`.\n")
+	b.WriteString("\nRequired result fields: name, caste, role, task, status, summary. Include files/tests/blockers/response when relevant.\n")
+	b.WriteString("Builder may edit code. Tracker, Scout, Archaeologist, and Watcher should stay read-only unless the user explicitly asked otherwise.\n")
+	return strings.TrimSpace(b.String())
+}
+
+func swarmPlanMaps(plans []swarmWorkerPlan) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(plans))
+	for _, plan := range plans {
+		entry := map[string]interface{}{
+			"stage":           plan.Stage,
+			"wave":            plan.Wave,
+			"name":            plan.Name,
+			"caste":           plan.Caste,
+			"role":            plan.Role,
+			"task":            plan.Task,
+			"task_id":         plan.TaskID,
+			"agent_name":      plan.AgentName,
+			"brief":           plan.Brief,
+			"output_paths":    plan.OutputPaths,
+			"status":          "planned",
+			"timeout_seconds": plan.TimeoutSeconds,
+		}
+		if plan.ResponseContract != nil {
+			entry["response_contract"] = plan.ResponseContract
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
 func initializeSwarmRun(swarmID string) error {
 	if err := os.MkdirAll(filepath.Join(store.BasePath(), "swarms", swarmID, "responses"), 0755); err != nil {
 		return err
@@ -308,6 +547,277 @@ func initializeSwarmRun(swarmID string) error {
 		SwarmID: swarmID,
 		StartAt: time.Now().UTC().Format(time.RFC3339),
 	})
+}
+
+func loadExternalSwarmCompletion(path string) (externalSwarmCompletion, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return externalSwarmCompletion{}, fmt.Errorf("flag --completion-file is required")
+	}
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return externalSwarmCompletion{}, fmt.Errorf("read completion file: %w", err)
+	}
+
+	var completion externalSwarmCompletion
+	if err := json.Unmarshal(data, &completion); err != nil {
+		return externalSwarmCompletion{}, fmt.Errorf("parse completion file: %w", err)
+	}
+	if completion.activeManifest() != nil {
+		return completion, nil
+	}
+
+	var envelope struct {
+		Result externalSwarmCompletion `json:"result"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return externalSwarmCompletion{}, fmt.Errorf("parse completion envelope: %w", err)
+	}
+	if envelope.Result.activeManifest() == nil {
+		return externalSwarmCompletion{}, fmt.Errorf("completion file must include swarm_manifest")
+	}
+	return envelope.Result, nil
+}
+
+func (c externalSwarmCompletion) activeManifest() *swarmManifest {
+	if c.SwarmManifest != nil {
+		return c.SwarmManifest
+	}
+	return c.Manifest
+}
+
+func (c externalSwarmCompletion) workerResults() []swarmWorkerExecution {
+	results := make([]swarmWorkerExecution, 0, len(c.Dispatches)+len(c.Workers)+len(c.Results)+len(c.Responses)+len(c.WorkerResults))
+	results = append(results, c.Dispatches...)
+	results = append(results, c.Workers...)
+	results = append(results, c.Results...)
+	for _, response := range c.Responses {
+		results = append(results, swarmWorkerExecution{
+			Role:     response.Role,
+			Caste:    response.Role,
+			Status:   response.Status,
+			Summary:  response.Summary,
+			Files:    append([]string{}, response.FilesTouched...),
+			Tests:    append([]string{}, response.TestsWritten...),
+			Response: response,
+		})
+	}
+	for _, workerResult := range c.WorkerResults {
+		results = append(results, swarmWorkerExecution{
+			Name:     workerResult.WorkerName,
+			Caste:    workerResult.Caste,
+			Status:   workerResult.Status,
+			Summary:  workerResult.Summary,
+			Duration: workerResult.Duration.Seconds(),
+			Files:    append(append([]string{}, workerResult.FilesCreated...), workerResult.FilesModified...),
+			Tests:    append([]string{}, workerResult.TestsWritten...),
+			Blockers: append([]string{}, workerResult.Blockers...),
+		})
+	}
+	return results
+}
+
+func runSwarmFinalize(root string, completion externalSwarmCompletion) (map[string]interface{}, error) {
+	if store == nil {
+		return nil, fmt.Errorf("no store initialized")
+	}
+	manifest := completion.activeManifest()
+	if manifest == nil {
+		return nil, fmt.Errorf("completion file must include swarm_manifest")
+	}
+	if (manifest.DispatchMode != "plan-only" && manifest.DispatchMode != "agent-delegate") || !manifest.RequiresFinalizer {
+		return nil, fmt.Errorf("swarm_manifest must come from `aether swarm --plan-only` or an agent-delegate swarm response")
+	}
+	if len(manifest.Dispatches) == 0 {
+		return nil, fmt.Errorf("swarm_manifest contains no dispatches")
+	}
+	if strings.TrimSpace(manifest.Root) != "" && !sameCleanPath(manifest.Root, root) {
+		return nil, fmt.Errorf("swarm_manifest root does not match current workspace (manifest=%s current=%s)", manifest.Root, root)
+	}
+
+	state, _ := loadColonyState()
+	startedAt := time.Now().UTC()
+	runHandle, err := beginRuntimeSpawnRun("swarm", startedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize swarm run: %w", err)
+	}
+	runStatus := "failed"
+	defer func() {
+		finishRuntimeSpawnRun(runHandle, runStatus, time.Now().UTC())
+	}()
+
+	swarmID := strings.TrimSpace(manifest.SwarmID)
+	if swarmID == "" {
+		swarmID = fmt.Sprintf("swarm-%d", startedAt.Unix())
+	}
+	if err := initializeSwarmRun(swarmID); err != nil {
+		return nil, fmt.Errorf("initialize swarm workspace: %w", err)
+	}
+
+	runs, err := mergeExternalSwarmResults(*manifest, completion.workerResults())
+	if err != nil {
+		return nil, err
+	}
+	if err := recordExternalSwarmRun(swarmID, runs); err != nil {
+		return nil, err
+	}
+
+	status, recommendation, rootCause, solution, blockers := summarizeSwarmOutcome(runs)
+	runStatus = summarizeRunStatus(status)
+	filesTouched, testsWritten := collectSwarmTouchedFiles(runs)
+	next := swarmNextCommand(state, status)
+
+	if err := store.SaveJSON(filepath.ToSlash(filepath.Join("swarms", swarmID, "result.json")), map[string]interface{}{
+		"swarm_id":       swarmID,
+		"target":         manifest.Target,
+		"status":         status,
+		"root_cause":     rootCause,
+		"solution":       solution,
+		"recommendation": recommendation,
+		"workers":        runs,
+		"files":          filesTouched,
+		"tests":          testsWritten,
+		"blockers":       blockers,
+		"completed_at":   time.Now().UTC().Format(time.RFC3339),
+		"dispatch_mode":  "external-task",
+	}); err != nil {
+		return nil, fmt.Errorf("write swarm result: %w", err)
+	}
+
+	return map[string]interface{}{
+		"mode":                "destroy",
+		"autopilot_available": true,
+		"swarm_id":            swarmID,
+		"target":              manifest.Target,
+		"status":              status,
+		"root_cause":          rootCause,
+		"solution":            solution,
+		"recommendation":      recommendation,
+		"workers":             swarmExecutionsForJSON(runs),
+		"dispatches":          swarmExecutionsForJSON(runs),
+		"worker_count":        len(runs),
+		"wave_count":          manifest.WaveCount,
+		"files_touched":       filesTouched,
+		"tests_written":       testsWritten,
+		"blockers":            blockers,
+		"dispatch_mode":       "external-task",
+		"dispatch_contract":   manifest.DispatchContract,
+		"next":                next,
+		"watch":               false,
+	}, nil
+}
+
+func mergeExternalSwarmResults(manifest swarmManifest, results []swarmWorkerExecution) ([]swarmWorkerExecution, error) {
+	resultByName := make(map[string]swarmWorkerExecution, len(results))
+	resultByRole := make(map[string]swarmWorkerExecution, len(results))
+	for _, result := range results {
+		if name := strings.TrimSpace(result.Name); name != "" {
+			resultByName[name] = result
+		}
+		if role := strings.TrimSpace(result.Role); role != "" {
+			resultByRole[role] = result
+		}
+		if result.Response.Role != "" {
+			resultByRole[result.Response.Role] = result
+		}
+	}
+
+	merged := make([]swarmWorkerExecution, 0, len(manifest.Dispatches))
+	for _, plan := range manifest.Dispatches {
+		result, ok := resultByName[strings.TrimSpace(plan.Name)]
+		if !ok {
+			result, ok = resultByRole[strings.TrimSpace(plan.Role)]
+		}
+		if !ok {
+			return nil, fmt.Errorf("missing external swarm worker result for %s", plan.Name)
+		}
+
+		execution := swarmWorkerExecution{
+			Name:         plan.Name,
+			Caste:        plan.Caste,
+			Role:         plan.Role,
+			Task:         plan.Task,
+			Status:       normalizeRuntimeDispatchStatus(result.Status),
+			Summary:      strings.TrimSpace(result.Summary),
+			Duration:     result.Duration,
+			Files:        append([]string{}, result.Files...),
+			Tests:        append([]string{}, result.Tests...),
+			Blockers:     append([]string{}, result.Blockers...),
+			Response:     result.Response,
+			ResponsePath: result.ResponsePath,
+		}
+		if strings.TrimSpace(result.Name) != "" {
+			execution.Name = strings.TrimSpace(result.Name)
+		}
+		if strings.TrimSpace(result.Caste) != "" {
+			execution.Caste = strings.TrimSpace(result.Caste)
+		}
+		if strings.TrimSpace(result.Role) != "" {
+			execution.Role = strings.TrimSpace(result.Role)
+		}
+		if strings.TrimSpace(result.Task) != "" {
+			execution.Task = strings.TrimSpace(result.Task)
+		}
+		if execution.Response.Role == "" {
+			execution.Response.Role = execution.Role
+		}
+		if execution.Status == "" || execution.Status == "spawned" {
+			execution.Status = "completed"
+		}
+		if execution.Summary == "" && execution.Response.Summary != "" {
+			execution.Summary = execution.Response.Summary
+		}
+		if execution.Summary == "" && len(execution.Blockers) > 0 {
+			execution.Summary = strings.Join(execution.Blockers, "; ")
+		}
+		if execution.Summary == "" {
+			execution.Summary = fmt.Sprintf("%s worker completed without a structured summary.", execution.Role)
+		}
+		execution.Files = append(execution.Files, execution.Response.FilesTouched...)
+		execution.Tests = append(execution.Tests, execution.Response.TestsWritten...)
+		execution.Files = swarmCompactStrings(execution.Files)
+		execution.Tests = swarmCompactStrings(execution.Tests)
+		execution.Blockers = swarmCompactStrings(execution.Blockers)
+		merged = append(merged, execution)
+	}
+	return merged, nil
+}
+
+func recordExternalSwarmRun(swarmID string, runs []swarmWorkerExecution) error {
+	spawnTree := agent.NewSpawnTree(store, "spawn-tree.txt")
+	for _, run := range runs {
+		wave := 1
+		switch run.Role {
+		case "builder":
+			wave = 2
+		case "watcher":
+			wave = 3
+		}
+		if err := spawnTree.RecordSpawn("Swarm", run.Caste, run.Name, run.Task, wave); err != nil {
+			return fmt.Errorf("record swarm spawn %s: %w", run.Name, err)
+		}
+		summary := strings.TrimSpace(run.Summary)
+		if summary == "" {
+			summary = fmt.Sprintf("%s worker finished with status %s", run.Role, run.Status)
+		}
+		if err := spawnTree.UpdateStatus(run.Name, run.Status, summary); err != nil {
+			return fmt.Errorf("complete swarm worker %s: %w", run.Name, err)
+		}
+		if err := updateSwarmDisplayStatus(swarmID, run.Name, run.Status); err != nil {
+			return fmt.Errorf("update swarm display %s: %w", run.Name, err)
+		}
+		response := run.Response
+		if err := recordSwarmFinding(swarmID, run.Name, &response, run); err != nil {
+			return fmt.Errorf("record swarm finding %s: %w", run.Name, err)
+		}
+	}
+	return nil
 }
 
 func buildSwarmInvestigationPlans(root, target string) []swarmWorkerPlan {
@@ -870,6 +1380,31 @@ func renderSwarmCompatibilityVisual(result map[string]interface{}) string {
 		b.WriteString(renderNextUp(
 			primary,
 			`Run `+"`aether swarm \"describe the problem\"`"+` to launch the bug-destroyer flow.`,
+		))
+		return b.String()
+	}
+
+	dispatchMode := strings.TrimSpace(stringValue(result["dispatch_mode"]))
+	requiresFinalizer, _ := result["requires_finalizer"].(bool)
+	if requiresFinalizer || dispatchMode == "plan-only" || dispatchMode == "agent-delegate" {
+		b.WriteString("Swarm dispatch manifest ready.\n")
+		if swarmID := strings.TrimSpace(stringValue(result["swarm_id"])); swarmID != "" {
+			b.WriteString("Swarm ID: " + swarmID + "\n")
+		}
+		if target != "" {
+			b.WriteString("Target: " + target + "\n")
+		}
+		if dispatchMode != "" {
+			b.WriteString("Dispatch: " + dispatchMode + "\n")
+		}
+		renderSwarmWorkers(&b, result)
+		finalizer := strings.TrimSpace(stringValue(result["finalizer_command"]))
+		if finalizer == "" {
+			finalizer = "AETHER_OUTPUT_MODE=json aether swarm-finalize --completion-file <file>"
+		}
+		b.WriteString(renderNextUp(
+			"Host platform should dispatch the swarm workers above, then run `"+finalizer+"`.",
+			"Do not hand-edit `.aether/data/`; the finalizer writes swarm artifacts and status.",
 		))
 		return b.String()
 	}

--- a/cmd/swarm_cmd_test.go
+++ b/cmd/swarm_cmd_test.go
@@ -235,3 +235,142 @@ func TestSwarmDestroySurfacesBlockedWorkers(t *testing.T) {
 		t.Fatalf("unexpected blocker payload: %v", blockers)
 	}
 }
+
+func TestSwarmPlanOnlyPrintsManifestWithoutMutatingState(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+	t.Setenv("AETHER_OUTPUT_MODE", "json")
+
+	dataDir := setupBuildFlowTest(t)
+	root := filepath.Dir(filepath.Dir(dataDir))
+	withWorkingDir(t, root)
+
+	goal := "Plan visible swarm workers"
+	createTestColonyState(t, dataDir, colony.ColonyState{
+		Version: "3.0",
+		Goal:    &goal,
+		State:   colony.StateREADY,
+	})
+
+	rootCmd.SetArgs([]string{"swarm", "--plan-only", "Auth panic when session is missing"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("swarm --plan-only returned error: %v", err)
+	}
+
+	env := parseEnvelope(t, stdout.(*bytes.Buffer).String())
+	result := env["result"].(map[string]interface{})
+	if got := result["dispatch_mode"]; got != "plan-only" {
+		t.Fatalf("dispatch_mode = %v, want plan-only", got)
+	}
+	if got, _ := result["requires_finalizer"].(bool); !got {
+		t.Fatalf("requires_finalizer = %v, want true", result["requires_finalizer"])
+	}
+	manifest := result["swarm_manifest"].(map[string]interface{})
+	if got := manifest["finalizer_command"]; !strings.Contains(stringValue(got), "swarm-finalize") {
+		t.Fatalf("finalizer_command = %v", got)
+	}
+	workers := result["workers"].([]interface{})
+	if len(workers) != 5 {
+		t.Fatalf("workers = %d, want 5", len(workers))
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "swarms")); !os.IsNotExist(err) {
+		t.Fatalf("plan-only should not create swarm artifacts, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "spawn-tree.txt")); !os.IsNotExist(err) {
+		t.Fatalf("plan-only should not write spawn-tree, stat err=%v", err)
+	}
+}
+
+func TestSwarmFinalizeRecordsExternalTaskResults(t *testing.T) {
+	saveGlobals(t)
+	resetRootCmd(t)
+	t.Setenv("AETHER_OUTPUT_MODE", "json")
+
+	dataDir := setupBuildFlowTest(t)
+	root := filepath.Dir(filepath.Dir(dataDir))
+	withWorkingDir(t, root)
+
+	goal := "Finalize visible swarm workers"
+	createTestColonyState(t, dataDir, colony.ColonyState{
+		Version: "3.0",
+		Goal:    &goal,
+		State:   colony.StateREADY,
+	})
+
+	planResult, err := runSwarmPlanOnly(root, "Auth panic when session is missing")
+	if err != nil {
+		t.Fatalf("runSwarmPlanOnly: %v", err)
+	}
+	manifest := planResult["swarm_manifest"].(swarmManifest)
+	dispatches := make([]swarmWorkerExecution, 0, len(manifest.Dispatches))
+	for _, plan := range manifest.Dispatches {
+		response := swarmWorkerResponse{
+			Role:           plan.Role,
+			Status:         "completed",
+			Summary:        plan.Role + " completed externally.",
+			Recommendation: "Continue with the active colony lifecycle.",
+			Verification:   []string{"go test ./..."},
+		}
+		if plan.Role == "tracker" {
+			response.RootCause = "missing session guard"
+		}
+		if plan.Role == "builder" {
+			response.ProposedFix = "restore the missing session guard"
+			response.FilesTouched = []string{"pkg/auth/handler.go"}
+			response.TestsWritten = []string{"pkg/auth/handler_test.go"}
+		}
+		dispatches = append(dispatches, swarmWorkerExecution{
+			Name:     plan.Name,
+			Caste:    plan.Caste,
+			Role:     plan.Role,
+			Task:     plan.Task,
+			Status:   "completed",
+			Summary:  response.Summary,
+			Files:    append([]string{}, response.FilesTouched...),
+			Tests:    append([]string{}, response.TestsWritten...),
+			Response: response,
+		})
+	}
+
+	completionPath := filepath.Join(t.TempDir(), "swarm-completion.json")
+	data, err := json.Marshal(map[string]interface{}{
+		"swarm_manifest": manifest,
+		"dispatches":     dispatches,
+	})
+	if err != nil {
+		t.Fatalf("marshal completion: %v", err)
+	}
+	if err := os.WriteFile(completionPath, data, 0644); err != nil {
+		t.Fatalf("write completion: %v", err)
+	}
+
+	resetRootCmd(t)
+	t.Setenv("AETHER_OUTPUT_MODE", "json")
+	stdout = &bytes.Buffer{}
+	rootCmd.SetArgs([]string{"swarm-finalize", "--completion-file", completionPath})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("swarm-finalize returned error: %v", err)
+	}
+
+	env := parseEnvelope(t, stdout.(*bytes.Buffer).String())
+	result := env["result"].(map[string]interface{})
+	if got := result["dispatch_mode"]; got != "external-task" {
+		t.Fatalf("dispatch_mode = %v, want external-task", got)
+	}
+	if got := result["status"]; got != "completed" {
+		t.Fatalf("status = %v, want completed", got)
+	}
+	resultPath := filepath.Join(dataDir, "swarms", manifest.SwarmID, "result.json")
+	if _, err := os.Stat(resultPath); err != nil {
+		t.Fatalf("expected swarm result artifact: %v", err)
+	}
+	spawnTreeData, err := os.ReadFile(filepath.Join(dataDir, "spawn-tree.txt"))
+	if err != nil {
+		t.Fatalf("read spawn-tree: %v", err)
+	}
+	for _, caste := range []string{"tracker", "scout", "archaeologist", "builder", "watcher"} {
+		if !strings.Contains(string(spawnTreeData), "|Swarm|"+caste+"|") {
+			t.Fatalf("spawn tree missing %s entry:\n%s", caste, string(spawnTreeData))
+		}
+	}
+}

--- a/cmd/swarm_wrapper_ceremony_test.go
+++ b/cmd/swarm_wrapper_ceremony_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSwarmWrapperCeremonyContract(t *testing.T) {
+	repoRoot, err := repoRootForCommandSourceTest()
+	if err != nil {
+		t.Fatalf("failed to find repo root: %v", err)
+	}
+
+	wrapperPaths := []string{
+		filepath.Join(repoRoot, ".claude", "commands", "ant", "swarm.md"),
+		filepath.Join(repoRoot, ".opencode", "commands", "ant", "swarm.md"),
+	}
+
+	required := []string{
+		"## Watch Mode",
+		"AETHER_OUTPUT_MODE=visual aether swarm --watch",
+		"## Swarm Manifest",
+		"AETHER_OUTPUT_MODE=json aether swarm --plan-only $ARGUMENTS",
+		"result.swarm_manifest",
+		"dispatch_mode: agent-delegate",
+		"## Wave Execution",
+		"Wave 1 investigation workers may run together.",
+		"Wave 2 builder waits for wave 1 summaries.",
+		"Wave 3 watcher waits for builder completion.",
+		`subagent_type="{agent_name}"`,
+		"AETHER_OUTPUT_MODE=json aether spawn-log",
+		"AETHER_OUTPUT_MODE=json aether spawn-complete",
+		"## Completion Packet",
+		"AETHER_OUTPUT_MODE=json aether swarm-finalize --completion-file",
+		"## After Swarm",
+		"Do NOT run nested subprocess swarm workers",
+		"Do NOT run `aether swarm` without `--plan-only`",
+	}
+
+	inOrder := []string{
+		"## Watch Mode",
+		"AETHER_OUTPUT_MODE=visual aether swarm --watch",
+		"## Swarm Manifest",
+		"AETHER_OUTPUT_MODE=json aether swarm --plan-only $ARGUMENTS",
+		"## Wave Execution",
+		"## Completion Packet",
+		"AETHER_OUTPUT_MODE=json aether swarm-finalize --completion-file",
+		"## After Swarm",
+		"## Guardrails",
+	}
+
+	for _, wrapperPath := range wrapperPaths {
+		content, err := os.ReadFile(wrapperPath)
+		if err != nil {
+			t.Fatalf("read %s: %v", wrapperPath, err)
+		}
+		text := string(content)
+		for _, want := range required {
+			if !strings.Contains(text, want) {
+				t.Errorf("%s missing %q", wrapperPath, want)
+			}
+		}
+		assertSubstringsInOrder(t, wrapperPath, text, inOrder)
+		for _, forbidden := range []string{
+			"To launch the stubborn bug-destroyer flow, execute `AETHER_OUTPUT_MODE=visual aether swarm \"$ARGUMENTS\"` directly.",
+			"AETHER_OUTPUT_MODE=visual aether swarm \"$ARGUMENTS\"",
+			"manually reconstruct swarm artifacts",
+		} {
+			if strings.Contains(text, forbidden) {
+				t.Errorf("%s still contains old swarm pass-through contract %q", wrapperPath, forbidden)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add aether swarm --plan-only and aether swarm-finalize so Claude/OpenCode can spawn visible bug-destroyer workers.
- Update swarm command wrappers, command guide, and Codex build-cycle skill to use the runtime manifest/finalizer contract.
- Add wrapper/runtime tests covering swarm host orchestration.

## Verification
- git diff --check
- go test ./cmd focused swarm/guide/wrapper contracts
- go test ./... -count=1
- go vet ./...
- go build ./cmd/aether